### PR TITLE
refactor: modularize purchase table and dialog

### DIFF
--- a/src/components/purchase/hooks/usePurchaseItemManager.ts
+++ b/src/components/purchase/hooks/usePurchaseItemManager.ts
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import type { PurchaseItem } from '../types/purchase.types';
+import { toast } from 'sonner';
+
+interface BahanBakuItem {
+  id: string;
+  nama: string;
+  satuan: string;
+}
+
+interface UsePurchaseItemManagerProps {
+  bahanBaku: BahanBakuItem[];
+  items: PurchaseItem[];
+  addItem: (item: Omit<PurchaseItem, 'subtotal'>) => void;
+  updateItem: (index: number, item: Partial<PurchaseItem>) => void;
+}
+
+export const usePurchaseItemManager = ({
+  bahanBaku,
+  items,
+  addItem,
+  updateItem,
+}: UsePurchaseItemManagerProps) => {
+  const [newItem, setNewItem] = useState<Partial<PurchaseItem>>({
+    bahanBakuId: '',
+    nama: '',
+    kuantitas: 0,
+    satuan: '',
+    hargaSatuan: 0,
+    keterangan: '',
+  });
+
+  const [showAddItem, setShowAddItem] = useState(false);
+  const [editingItemIndex, setEditingItemIndex] = useState<number | null>(null);
+
+  const handleBahanBakuSelect = (bahanBakuId: string) => {
+    const selectedBahan = bahanBaku.find((b) => b.id === bahanBakuId);
+    if (selectedBahan) {
+      setNewItem((prev) => ({
+        ...prev,
+        bahanBakuId,
+        nama: selectedBahan.nama,
+        satuan: selectedBahan.satuan,
+      }));
+    }
+  };
+
+  const handleAddItem = () => {
+    if (!newItem.bahanBakuId || !newItem.nama || !newItem.kuantitas || !newItem.hargaSatuan) {
+      toast.error('Lengkapi data item terlebih dahulu');
+      return;
+    }
+
+    const isDuplicate = items.some((item) => item.bahanBakuId === newItem.bahanBakuId);
+    if (isDuplicate) {
+      toast.error('Bahan baku sudah ada dalam daftar pembelian');
+      return;
+    }
+
+    addItem({
+      bahanBakuId: newItem.bahanBakuId!,
+      nama: newItem.nama!,
+      kuantitas: newItem.kuantitas!,
+      satuan: newItem.satuan!,
+      hargaSatuan: newItem.hargaSatuan!,
+      keterangan: newItem.keterangan,
+    });
+
+    setNewItem({
+      bahanBakuId: '',
+      nama: '',
+      kuantitas: 0,
+      satuan: '',
+      hargaSatuan: 0,
+      keterangan: '',
+    });
+    setShowAddItem(false);
+    toast.success('Item berhasil ditambahkan');
+  };
+
+  const handleEditItem = (index: number) => {
+    setEditingItemIndex(index);
+    toast.info('Mode edit item aktif');
+  };
+
+  const handleSaveEditedItem = (index: number, updatedItem: Partial<PurchaseItem>) => {
+    if (!updatedItem.kuantitas || !updatedItem.hargaSatuan) {
+      toast.error('Kuantitas dan harga satuan harus diisi');
+      return;
+    }
+
+    updateItem(index, {
+      ...updatedItem,
+      subtotal: (updatedItem.kuantitas || 0) * (updatedItem.hargaSatuan || 0),
+    });
+
+    setEditingItemIndex(null);
+    toast.success('Item berhasil diperbarui');
+  };
+
+  const handleCancelEditItem = () => {
+    setEditingItemIndex(null);
+  };
+
+  return {
+    newItem,
+    setNewItem,
+    showAddItem,
+    setShowAddItem,
+    editingItemIndex,
+    handleBahanBakuSelect,
+    handleAddItem,
+    handleEditItem,
+    handleSaveEditedItem,
+    handleCancelEditItem,
+  };
+};
+

--- a/src/components/purchase/hooks/usePurchaseTableDialogs.ts
+++ b/src/components/purchase/hooks/usePurchaseTableDialogs.ts
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import type { PurchaseStatus, Purchase } from '../types/purchase.types';
+
+interface StatusValidation {
+  canChange: boolean;
+  warnings: string[];
+  errors: string[];
+}
+
+interface DialogState {
+  statusConfirmation: {
+    isOpen: boolean;
+    purchase: Purchase | null;
+    newStatus: PurchaseStatus | null;
+    validation: StatusValidation | null;
+  };
+  deleteConfirmation: {
+    isOpen: boolean;
+    purchase: Purchase | null;
+    isDeleting: boolean;
+  };
+  bulkDeleteConfirmation: {
+    isOpen: boolean;
+    selectedCount: number;
+    isDeleting: boolean;
+  };
+}
+
+const initialDialogState: DialogState = {
+  statusConfirmation: {
+    isOpen: false,
+    purchase: null,
+    newStatus: null,
+    validation: null,
+  },
+  deleteConfirmation: {
+    isOpen: false,
+    purchase: null,
+    isDeleting: false,
+  },
+  bulkDeleteConfirmation: {
+    isOpen: false,
+    selectedCount: 0,
+    isDeleting: false,
+  },
+};
+
+export const usePurchaseTableDialogs = () => {
+  const [dialogState, setDialogState] = useState<DialogState>(initialDialogState);
+
+  const openDelete = (purchase: Purchase) =>
+    setDialogState((prev) => ({
+      ...prev,
+      deleteConfirmation: { isOpen: true, purchase, isDeleting: false },
+    }));
+
+  const setDeleteLoading = (isDeleting: boolean) =>
+    setDialogState((prev) => ({
+      ...prev,
+      deleteConfirmation: { ...prev.deleteConfirmation, isDeleting },
+    }));
+
+  const resetDelete = () =>
+    setDialogState((prev) => ({
+      ...prev,
+      deleteConfirmation: initialDialogState.deleteConfirmation,
+    }));
+
+  const openBulkDelete = (selectedCount: number) =>
+    setDialogState((prev) => ({
+      ...prev,
+      bulkDeleteConfirmation: {
+        isOpen: true,
+        selectedCount,
+        isDeleting: false,
+      },
+    }));
+
+  const setBulkDeleteLoading = (isDeleting: boolean) =>
+    setDialogState((prev) => ({
+      ...prev,
+      bulkDeleteConfirmation: { ...prev.bulkDeleteConfirmation, isDeleting },
+    }));
+
+  const resetBulkDelete = () =>
+    setDialogState((prev) => ({
+      ...prev,
+      bulkDeleteConfirmation: initialDialogState.bulkDeleteConfirmation,
+    }));
+
+  const openStatus = (purchase: Purchase, newStatus: PurchaseStatus, validation: StatusValidation) =>
+    setDialogState((prev) => ({
+      ...prev,
+      statusConfirmation: {
+        isOpen: true,
+        purchase,
+        newStatus,
+        validation,
+      },
+    }));
+
+  const resetStatus = () =>
+    setDialogState((prev) => ({
+      ...prev,
+      statusConfirmation: initialDialogState.statusConfirmation,
+    }));
+
+  return {
+    dialogState,
+    openDelete,
+    setDeleteLoading,
+    resetDelete,
+    openBulkDelete,
+    setBulkDeleteLoading,
+    resetBulkDelete,
+    openStatus,
+    resetStatus,
+  };
+};
+
+export type { DialogState };
+export { initialDialogState };
+


### PR DESCRIPTION
## Summary
- extract dialog state logic to `usePurchaseTableDialogs`
- extract item management logic to `usePurchaseItemManager`
- wire table and dialog components to new hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/purchase/components/PurchaseTable.tsx src/components/purchase/components/PurchaseDialog.tsx src/components/purchase/hooks/usePurchaseItemManager.ts src/components/purchase/hooks/usePurchaseTableDialogs.ts`

------
https://chatgpt.com/codex/tasks/task_e_689d9939e7b4832e8faa5175bf994158