### PR TITLE
Pass userId to operational cost API

### DIFF
--- a/src/components/operational-costs/services/operationalCostApi.ts
+++ b/src/components/operational-costs/services/operationalCostApi.ts
@@ -30,17 +30,20 @@ const getCurrentUserId = async (): Promise<string | null> => {
 
 export const operationalCostApi = {
   // Get all costs with filters
-  async getCosts(filters?: CostFilters): Promise<ApiResponse<OperationalCost[]>> {
+  async getCosts(
+    filters?: CostFilters,
+    userId?: string
+  ): Promise<ApiResponse<OperationalCost[]>> {
     try {
-      const userId = await getCurrentUserId();
-      if (!userId) {
+      const resolvedUserId = userId ?? await getCurrentUserId();
+      if (!resolvedUserId) {
         return { data: [], error: 'User tidak ditemukan. Silakan login kembali.' };
       }
 
       let query = supabase
         .from('operational_costs')
         .select('*')
-        .eq('user_id', userId) // ✅ Add user filter
+        .eq('user_id', resolvedUserId) // ✅ Add user filter
         .order('created_at', { ascending: false });
 
       if (filters?.jenis) {

--- a/src/components/profitAnalysis/services/profitAnalysisApi.ts
+++ b/src/components/profitAnalysis/services/profitAnalysisApi.ts
@@ -315,12 +315,12 @@ export const profitAnalysisApi = {
       
       const [
         transactions,
-        materials, 
+        materials,
         operationalCosts
       ] = await Promise.all([
         financialApi.getFinancialTransactions(userId),
         getWarehouseData(userId),
-        operationalCostApi.getCosts()
+        operationalCostApi.getCosts(undefined, userId)
       ]);
 
       // Handle potential errors from data sources
@@ -415,7 +415,7 @@ export const profitAnalysisApi = {
       if (error) {
         // Fallback to direct API call
         logger.warn('OpEx breakdown function failed, using fallback');
-        const opexResult = await operationalCostApi.getCosts();
+        const opexResult = await operationalCostApi.getCosts(undefined, userId);
         const activeCosts = (opexResult.data || []).filter(c => c.status === 'aktif');
         const totalOpEx = activeCosts.reduce((sum, c) => sum + (c.jumlah_per_bulan || 0), 0);
 


### PR DESCRIPTION
## Summary
- Forward userId to operational cost API during profit analysis calculations
- Allow operational cost API to accept an optional userId and skip internal lookup when provided

## Testing
- `npm run lint` (fails: 2658 problems)
- `npm test` (fails: missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689da6061a44832ea884207fe07d4f8e