### PR TITLE
chore: remove unused formatDate

### DIFF
--- a/src/components/update/UpdatesPage.tsx
+++ b/src/components/update/UpdatesPage.tsx
@@ -46,16 +46,6 @@ export const UpdatesPage: React.FC = () => {
     await fetchAllUpdates();
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('id-ID', {
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
-
   // Filter updates based on selected filters and unread status
   const filteredUpdates = updates.filter(update => {
     const matchesPriority = priorityFilter === 'all' || update.priority === priorityFilter;


### PR DESCRIPTION
## Summary
- remove dead `formatDate` helper from UpdatesPage component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689daa0025a8832eb7ab41daa8dd22dd