### PR TITLE
fix: allow add item toggle in purchase dialog

### DIFF
--- a/src/components/purchase/components/PurchaseDialog.tsx
+++ b/src/components/purchase/components/PurchaseDialog.tsx
@@ -117,7 +117,11 @@ const PurchaseDialog: React.FC<PurchaseDialogProps> = ({
       setShowAddItem(false);
       handleCancelEditItem();
     }
-  }, [isOpen, setNewItem, setShowAddItem, handleCancelEditItem]);
+    // We intentionally only depend on `isOpen` to avoid resetting
+    // state on every render which would prevent the add-item form
+    // from toggling correctly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
 
   // ✅ Handle form submission
   const onSubmit = async () => {


### PR DESCRIPTION
## Summary
- stop effect from resetting add-item state on every render so the "Tambah Item" button works

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Unexpected any, 2657 problems)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db821d468832e9168d0d003d2e74e