### PR TITLE
Allow duplicate materials in purchase dialog

### DIFF
--- a/src/components/purchase/components/PurchaseDialog.tsx
+++ b/src/components/purchase/components/PurchaseDialog.tsx
@@ -400,9 +400,7 @@ const PurchaseDialog: React.FC<PurchaseDialogProps> = ({
                             <SelectValue placeholder="Pilih bahan baku" />
                           </SelectTrigger>
                           <SelectContent>
-                            {bahanBaku
-                              .filter(bahan => !formData.items.some(item => item.bahanBakuId === bahan.id))
-                              .map((bahan) => (
+                            {bahanBaku.map((bahan) => (
                               <SelectItem key={bahan.id} value={bahan.id}>
                                 {bahan.nama} ({bahan.satuan})
                               </SelectItem>

--- a/src/components/purchase/hooks/usePurchaseItemManager.ts
+++ b/src/components/purchase/hooks/usePurchaseItemManager.ts
@@ -51,12 +51,6 @@ export const usePurchaseItemManager = ({
       return;
     }
 
-    const isDuplicate = items.some((item) => item.bahanBakuId === newItem.bahanBakuId);
-    if (isDuplicate) {
-      toast.error('Bahan baku sudah ada dalam daftar pembelian');
-      return;
-    }
-
     addItem({
       bahanBakuId: newItem.bahanBakuId!,
       nama: newItem.nama!,


### PR DESCRIPTION
## Summary
- Remove material filtering in purchase dialog so all materials are selectable
- Drop duplicate check when adding purchase items to permit repeated materials

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/purchase/components/PurchaseDialog.tsx src/components/purchase/hooks/usePurchaseItemManager.ts && echo 'lint passed'`

------
https://chatgpt.com/codex/tasks/task_e_689dbccfb780832ebfc9162b6af77082