### PR TITLE
style: enhance operational cost header

### DIFF
--- a/src/components/operational-costs/OperationalCostPage.tsx
+++ b/src/components/operational-costs/OperationalCostPage.tsx
@@ -121,16 +121,43 @@ const OperationalCostContent: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-orange-50 rounded-lg">
-              <DollarSign className="h-6 w-6 text-orange-600" />
+      <div className="bg-gradient-to-r from-orange-500 to-red-500 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <div className="bg-white bg-opacity-20 p-3 rounded-xl backdrop-blur-sm">
+                <DollarSign className="h-8 w-8 text-white" />
+              </div>
+
+              <div>
+                <h1 className="text-2xl lg:text-3xl font-bold mb-2">
+                  Biaya Operasional
+                </h1>
+                <p className="text-white opacity-90">
+                  Kelola biaya operasional dan hitung overhead per produk
+                </p>
+              </div>
             </div>
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">Biaya Operasional</h1>
-              <p className="text-gray-600">Kelola biaya operasional dan hitung overhead per produk</p>
+
+            <div className="hidden md:flex gap-3">
+              <Button
+                onClick={handleOpenAddDialog}
+                className="flex items-center gap-2 bg-white bg-opacity-20 text-white border border-white border-opacity-30 hover:bg-white hover:bg-opacity-30 font-medium px-4 py-2 rounded-lg transition-all backdrop-blur-sm"
+              >
+                <Plus className="h-4 w-4" />
+                Tambah Biaya
+              </Button>
             </div>
+          </div>
+
+          <div className="flex md:hidden flex-col gap-3 mt-6">
+            <Button
+              onClick={handleOpenAddDialog}
+              className="w-full flex items-center justify-center gap-2 bg-white bg-opacity-20 text-white border border-white border-opacity-30 hover:bg-white hover:bg-opacity-30 font-medium px-4 py-3 rounded-lg transition-all backdrop-blur-sm"
+            >
+              <Plus className="h-4 w-4" />
+              Tambah Biaya
+            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- restyle operational cost page header with gradient and actions

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: multiple lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a30550ab90832eb4ba79f9f0793dd9