### PR TITLE
refactor: centralize data export triggers

### DIFF
--- a/src/components/invoice/InvoicePage.tsx
+++ b/src/components/invoice/InvoicePage.tsx
@@ -113,7 +113,7 @@ const InvoicePage: React.FC = () => {
   const calculations = useInvoiceCalculations(items, discount, tax, shipping);
 
   // ✅ Print functionality
-  const { handlePrint, handleDownloadHTML, handleCopyToClipboard } = useInvoicePrint(invoiceNumber);
+  const { handlePrint } = useInvoicePrint(invoiceNumber);
 
   // ✅ Handle form data changes
   const handleDataChange = (changes: any) => {
@@ -223,7 +223,6 @@ const InvoicePage: React.FC = () => {
             onReset={resetForm}
             onDuplicate={duplicateInvoice}
             onPrint={handlePrint}
-            onDownload={handleDownloadHTML}
             orderId={orderId}
             orderNumber={orderData?.nomorPesanan}
           />

--- a/src/components/invoice/components/InvoiceActions.tsx
+++ b/src/components/invoice/components/InvoiceActions.tsx
@@ -9,7 +9,6 @@ interface InvoiceActionsProps {
   onReset: () => void;
   onDuplicate: () => void;
   onPrint: () => void;
-  onDownload: () => void;
   orderId?: string;
   orderNumber?: string;
   className?: string;
@@ -20,7 +19,6 @@ export const InvoiceActions: React.FC<InvoiceActionsProps> = ({
   onReset,
   onDuplicate,
   onPrint,
-  onDownload,
   orderId,
   orderNumber,
   className = ''
@@ -79,14 +77,6 @@ export const InvoiceActions: React.FC<InvoiceActionsProps> = ({
             >
               <Printer className="mr-2 h-4 w-4" />
               Print
-            </Button>
-            <Button 
-              onClick={onDownload}
-              variant="secondary"
-              className="bg-white/20 hover:bg-white/30 text-white border-white/20 text-sm"
-            >
-              <FileText className="mr-2 h-4 w-4" />
-              Download
             </Button>
           </div>
         </div>

--- a/src/components/profitAnalysis/components/DetailedBreakdownTable.tsx
+++ b/src/components/profitAnalysis/components/DetailedBreakdownTable.tsx
@@ -6,9 +6,9 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { 
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow 
 } from '@/components/ui/table';
-import { 
-  DollarSign, ShoppingCart, Calculator, TrendingUp, 
-  Download, Filter, Search
+import {
+  DollarSign, ShoppingCart, Calculator, TrendingUp,
+  Filter, Search
 } from 'lucide-react';
 
 import { 
@@ -26,7 +26,6 @@ import { RealTimeProfitCalculation } from '../types/profitAnalysis.types';
 export interface DetailedBreakdownTableProps {
   currentAnalysis: RealTimeProfitCalculation | null;
   isLoading: boolean;
-  showExport?: boolean;
   className?: string;
   /** ⬇️ COGS efektif (WAC) */
   effectiveCogs?: number;
@@ -178,7 +177,6 @@ const MemoizedSectionSummary = React.memo(({ section, sortedItems }: { section: 
 const DetailedBreakdownTable = ({
   currentAnalysis,
   isLoading,
-  showExport = true,
   className = '',
   effectiveCogs,
   hppBreakdown,
@@ -343,33 +341,6 @@ const DetailedBreakdownTable = ({
     });
   }, [sortBy, sortOrder]);
 
-  // ✅ OPTIMASI: useCallback untuk event handlers
-  const handleExport = useCallback(() => {
-    const exportData = breakdownSections.flatMap(section => 
-      section.items.map(item => ({
-        Kategori: section.title,
-        Item: item.name,
-        Jumlah: item.amount,
-        Persentase: item.percentage,
-        Tipe: item.type || 'N/A',
-        Jumlah_Transaksi: item.count || 1
-      }))
-    );
-
-    const csvContent = [
-      Object.keys(exportData[0] || {}).join(','),
-      ...exportData.map(row => Object.values(row).join(','))
-    ].join('\n');
-
-    const blob = new Blob([csvContent], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `breakdown-profit-${currentAnalysis?.period || 'export'}.csv`;
-    link.click();
-    URL.revokeObjectURL(url);
-  }, [breakdownSections, currentAnalysis?.period]);
-
   const handleTabChange = useCallback((tab: string) => {
     setActiveTab(tab);
   }, []);
@@ -450,13 +421,6 @@ const DetailedBreakdownTable = ({
             )}
           </div>
           
-          {/* Export Button */}
-          {showExport && (
-            <Button variant="outline" size="sm" onClick={handleExport}>
-              <Download className="w-4 h-4 mr-2" />
-              Export CSV
-            </Button>
-          )}
         </div>
 
         {/* Tab Navigation */}

--- a/src/components/profitAnalysis/components/ProfitDashboard.tsx
+++ b/src/components/profitAnalysis/components/ProfitDashboard.tsx
@@ -155,26 +155,6 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
     setRange(r);
   };
 
-  const handleExportData = () => {
-    if (!currentAnalysis) return;
-    
-    try {
-      const revenue = currentAnalysis.revenue_data?.total || 0;
-      const cogs = profitMetrics?.cogs ?? (currentAnalysis.cogs_data?.total || 0);
-      const opex = currentAnalysis.opex_data?.total || 0;
-      const csvContent = `Period,Revenue,COGS,OPEX,Gross Profit,Net Profit\n${currentPeriod},${revenue},${cogs},${opex},${revenue - cogs},${revenue - cogs - opex}`;
-      
-      const blob = new Blob([csvContent], { type: 'text/csv' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `analisis-profit-${currentPeriod}.csv`;
-      link.click();
-      URL.revokeObjectURL(url);
-    } catch (error) {
-      console.error('Error exporting:', error);
-    }
-  };
 
   const safeRevenue = profitMetrics?.revenue ?? currentAnalysis?.revenue_data?.total ?? 0;
   const safeCogs = profitMetrics?.cogs ?? currentAnalysis?.cogs_data?.total ?? 0;
@@ -200,7 +180,6 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
         ]}
         onPeriodChange={handlePeriodChange}
         onRefresh={handleRefresh}
-        onExportData={handleExportData}
         mode={mode}
         onModeChange={handleModeChange}
         dateRange={range}

--- a/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
+++ b/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
@@ -6,7 +6,6 @@ import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import {
   RotateCw,
-  Download,
   CheckCircle,
   AlertTriangle,
   Target,
@@ -47,7 +46,6 @@ export interface DashboardHeaderSectionProps {
   statusIndicators?: StatusIndicator[];
   onPeriodChange: (period: string) => void;
   onRefresh: () => void;
-  onExportData: () => void;
   // 🆕 Daily/Monthly mode + date range presets
   mode?: 'daily' | 'monthly';
   onModeChange?: (mode: 'daily' | 'monthly') => void;
@@ -70,7 +68,6 @@ const DashboardHeaderSection: React.FC<DashboardHeaderSectionProps> = ({
   statusIndicators = [],
   onPeriodChange,
   onRefresh,
-  onExportData,
   mode = 'monthly',
   onModeChange,
   dateRange,
@@ -157,14 +154,6 @@ const DashboardHeaderSection: React.FC<DashboardHeaderSectionProps> = ({
       >
         <RotateCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
         Refresh
-      </Button>
-      <Button
-        onClick={onExportData}
-        disabled={!hasValidData}
-        className="flex items-center gap-2 bg-white text-orange-600 hover:bg-gray-100 font-medium px-4 py-2 rounded-lg transition-all w-full md:w-auto justify-center"
-      >
-        <Download className="w-4 h-4" />
-        Export
       </Button>
     </>
   );

--- a/src/components/profitAnalysis/components/tabs/BreakdownTabContent.tsx
+++ b/src/components/profitAnalysis/components/tabs/BreakdownTabContent.tsx
@@ -32,10 +32,9 @@ const BreakdownTabContent: React.FC<BreakdownTabContentProps> = ({
   return (
     <TabsContent value="breakdown" className="space-y-4 sm:space-y-6 mt-6">
       <React.Suspense fallback={<div className="animate-pulse bg-gray-200 h-96 rounded-lg" />}>
-        <DetailedBreakdownTable 
-          currentAnalysis={currentAnalysis} 
-          isLoading={isLoading} 
-          showExport={true} 
+        <DetailedBreakdownTable
+          currentAnalysis={currentAnalysis}
+          isLoading={isLoading}
           // HPP total & breakdown WAC with fallback
           effectiveCogs={effectiveCogs ?? currentAnalysis?.cogs_data?.total ?? 0}
           hppBreakdown={hppBreakdown}

--- a/src/components/promoCalculator/promoList/PromoList.jsx
+++ b/src/components/promoCalculator/promoList/PromoList.jsx
@@ -10,7 +10,6 @@ import {
   Plus,
   Search,
   Filter,
-  Download,
   Trash2,
   AlertCircle,
   RefreshCw
@@ -406,14 +405,6 @@ const PromoList = () => {
                 >
                   <Filter className="h-4 w-4 mr-2" />
                   Filter
-                </Button>
-                {/* Export Button */}
-                <Button
-                  variant="outline"
-                  className="border-gray-300"
-                >
-                  <Download className="h-4 w-4 mr-2" />
-                  Export
                 </Button>
               </div>
               {/* Quick Stats */}

--- a/src/components/purchase/components/PurchaseHeader.tsx
+++ b/src/components/purchase/components/PurchaseHeader.tsx
@@ -4,7 +4,6 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
   ShoppingCart,
-  Download,
   TrendingUp,
   Clock,
   CheckCircle,
@@ -18,8 +17,6 @@ const PurchaseHeader: React.FC<PurchaseHeaderProps> = ({
   totalValue,
   pendingCount,
   onAddPurchase,
-  onExport,
-  onSettings,
   className = '',
 }) => {
   return (
@@ -53,16 +50,6 @@ const PurchaseHeader: React.FC<PurchaseHeaderProps> = ({
               Tambah Pembelian
             </Button>
 
-            {onExport && (
-              <Button
-                onClick={onExport}
-                variant="outline"
-                className="flex items-center justify-center gap-2 px-6 py-3 bg-white bg-opacity-10 text-white border-white border-opacity-30 font-semibold rounded-lg backdrop-blur-sm hover:bg-opacity-20 transition-colors duration-200"
-              >
-                <Download className="h-5 w-5" />
-                Export
-              </Button>
-            )}
           </div>
         </div>
 

--- a/src/components/purchase/types/purchase.types.ts
+++ b/src/components/purchase/types/purchase.types.ts
@@ -216,10 +216,7 @@ export interface PurchaseHeaderProps {
   totalValue: number;
   pendingCount: number;
   onAddPurchase: (intent?: AddPurchaseIntent) => void; // <— ubah ke terima intent
-  onExport?: () => void;
-  onSettings?: () => void;
   className?: string;
-  isExporting?: boolean;
 }
 
 export interface DataWarningBannerProps {
@@ -310,7 +307,6 @@ export interface LoadingStates {
   isLoading: boolean;
   isUpdating: boolean;
   isDeleting: boolean;
-  isExporting: boolean;
 }
 
 // Empty state types


### PR DESCRIPTION
## Summary
- remove per-page export buttons from promo, purchase, profit analysis, and invoice components
- drop unused export handlers and types
- rely on global `exportAllDataToExcel` via sidebar/mobile button

## Testing
- `pnpm lint` *(fails: Unexpected any & forbidden require in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a30e1a9a84832e8963c9baa5bbe16f