### PR TITLE
fix ImportExportDialog imports

### DIFF
--- a/docs/WAREHOUSE_IMPORT_TUTORIAL.md
+++ b/docs/WAREHOUSE_IMPORT_TUTORIAL.md
@@ -1,0 +1,14 @@
+# Warehouse Import Tutorial
+
+Panduan singkat untuk melakukan import stok bahan baku menggunakan *ImportExportDialog*.
+
+## Langkah penggunaan
+1. Buka dialog import dengan komponen `ImportExportDialog`.
+2. Pilih file CSV atau Excel yang sesuai dengan template.
+3. Tinjau data pada tampilan preview dan pastikan tidak ada error.
+4. Klik tombol **Import** untuk menyimpan data ke sistem.
+
+## Contoh impor hook
+```ts
+import { useImportExport } from '@/components/warehouse/hooks';
+```

--- a/src/components/warehouse/dialogs/ImportExportDialog.tsx
+++ b/src/components/warehouse/dialogs/ImportExportDialog.tsx
@@ -3,8 +3,8 @@ import { Button } from '@/components/ui/button';
 import { X, Upload } from 'lucide-react';
 import ImportControls from './ImportControls';
 import ImportPreview from './ImportPreview';
-import { useImportExport } from '../hooks/useImportExport';
-import { BahanBakuImport } from './import-utils';
+import { useImportExport } from '../hooks';
+import type { BahanBakuImport } from '../types';
 
 interface ImportDialogProps {
   isOpen: boolean;

--- a/src/components/warehouse/dialogs/ImportPreview.tsx
+++ b/src/components/warehouse/dialogs/ImportPreview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { AlertCircle, CheckCircle } from 'lucide-react';
-import { BahanBakuImport } from './import-utils';
+import type { BahanBakuImport } from '../types';
 
 interface ImportPreviewProps {
   preview: { valid: BahanBakuImport[]; errors: string[] };

--- a/src/components/warehouse/dialogs/import-utils.ts
+++ b/src/components/warehouse/dialogs/import-utils.ts
@@ -1,19 +1,6 @@
 import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
-
-export interface BahanBakuImport {
-  nama: string;
-  kategori: string;
-  supplier: string;
-  satuan: string;
-  expiry?: string;
-  stok: number;
-  minimum: number;
-  jumlahBeliKemasan: number;
-  isiPerKemasan: number;
-  satuanKemasan: string;
-  hargaTotalBeliKemasan: number;
-}
+import type { BahanBakuImport } from '../types';
 
 // Mapping of possible header names to our standard fields
 export const headerMap: Record<string, keyof BahanBakuImport> = {

--- a/src/components/warehouse/hooks/useImportExport.ts
+++ b/src/components/warehouse/hooks/useImportExport.ts
@@ -1,13 +1,8 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
-import {
-  BahanBakuImport,
-  headerMap,
-  requiredFields,
-  validate,
-  loadXLSX
-} from '../dialogs/import-utils';
+import type { BahanBakuImport } from '../types';
+import { headerMap, requiredFields, validate, loadXLSX } from '../dialogs/import-utils';
 
 interface UseImportExportProps {
   onImport: (data: BahanBakuImport[]) => Promise<boolean>;


### PR DESCRIPTION
## Summary
- revert unnecessary warehouseUtils refactor
- align ImportExportDialog and helpers with shared BahanBakuImport type
- add brief tutorial for importing warehouse stock

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a31541c920832e90218077db73085d