### PR TITLE
Remove purchase detail section

### DIFF
--- a/src/components/purchase/components/PurchaseDialog.tsx
+++ b/src/components/purchase/components/PurchaseDialog.tsx
@@ -188,27 +188,24 @@ const PurchaseDialog: React.FC<PurchaseDialogProps> = ({
   }, [formData.items.length, handleSubmit]);
 
   // ✅ ENHANCED: Handle payload from SimplePurchaseItemForm
-  const handleAddItemFromForm = useCallback((payload: PurchaseItemPayload) => {
-    // Convert payload to PurchaseItem format expected by the form
-    const purchaseItem: PurchaseItem = {
-      bahanBakuId: payload.bahanBakuId,
-      nama: payload.nama,
-      satuan: payload.satuan,
-      kuantitas: payload.kuantitas,
-      hargaSatuan: payload.hargaSatuan,
-      subtotal: payload.kuantitas * payload.hargaSatuan,
-      keterangan: payload.keterangan,
-      // ✅ NEW: Include packaging info if available
-      ...(payload.jumlahKemasan && { jumlahKemasan: payload.jumlahKemasan }),
-      ...(payload.isiPerKemasan && { isiPerKemasan: payload.isiPerKemasan }),
-      ...(payload.satuanKemasan && { satuanKemasan: payload.satuanKemasan }),
-      ...(payload.hargaTotalBeliKemasan && { hargaTotalBeliKemasan: payload.hargaTotalBeliKemasan }),
-    };
+  const handleAddItemFromForm = useCallback(
+    (payload: PurchaseItemPayload) => {
+      const purchaseItem: PurchaseItem = {
+        bahanBakuId: payload.bahanBakuId,
+        nama: payload.nama,
+        satuan: payload.satuan,
+        kuantitas: payload.kuantitas,
+        hargaSatuan: payload.hargaSatuan,
+        subtotal: payload.kuantitas * payload.hargaSatuan,
+        keterangan: payload.keterangan,
+      };
 
-    addItem(purchaseItem);
-    setShowAddItem(false);
-    toast.success(`${payload.nama} berhasil ditambahkan`);
-  }, [addItem, setShowAddItem]);
+      addItem(purchaseItem);
+      setShowAddItem(false);
+      toast.success(`${payload.nama} berhasil ditambahkan`);
+    },
+    [addItem, setShowAddItem]
+  );
 
   // ✅ Check if purchase can be edited (not completed)
   const canEdit = !purchase || purchase.status !== 'completed';
@@ -442,16 +439,9 @@ const PurchaseDialog: React.FC<PurchaseDialogProps> = ({
                           <div className="flex items-start justify-between">
                             <div className="flex-1 grid grid-cols-1 md:grid-cols-4 gap-4">
                               <div>
-                                <div className="font-medium">{item.nama}</div>
-                                {/* ID hidden since item creates new material */}
-                                {/* ✅ IMPROVED: Display packaging info with proper typing */}
-                                {item.jumlahKemasan && item.jumlahKemasan > 0 && item.isiPerKemasan && item.isiPerKemasan > 0 && (
-                                  <div className="text-xs text-gray-500 mt-1">
-                                    Kemasan: {item.jumlahKemasan} × {item.isiPerKemasan} {item.satuan || 'unit'}
-                                    {item.satuanKemasan ? ` (${item.satuanKemasan})` : ''}
-                                  </div>
-                                )}
-                              </div>
+                              <div className="font-medium">{item.nama}</div>
+                              {/* ID hidden since item creates new material */}
+                            </div>
                               <div className="text-right">
                                 <div className="font-medium">{item.kuantitas} {item.satuan}</div>
                                 <div className="text-sm text-gray-600">Kuantitas</div>

--- a/src/components/purchase/components/SimplePurchaseItemForm.tsx
+++ b/src/components/purchase/components/SimplePurchaseItemForm.tsx
@@ -7,14 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import {
-  Plus,
-  X,
-  CheckCircle2,
-  Package as PackageIcon,
-  Info,
-} from 'lucide-react';
+import { Plus, X, CheckCircle2 } from 'lucide-react';
 import { formatCurrency } from '@/utils/formatUtils';
 import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
@@ -27,13 +20,6 @@ interface FormData {
   // input utama
   kuantitas: string;            // Total yang dibeli (unit dasar bahan baku)
   totalBayar: string;           // Total bayar (untuk hitung harga satuan otomatis)
-
-  // optional: detail kemasan (nota)
-  jumlahKemasan?: string;
-  isiPerKemasan?: string;
-  satuanKemasan?: string;
-  hargaTotalBeliKemasan?: string; // total bayar dari nota (kalau diisi, override totalBayar)
-
   keterangan: string;
 }
 
@@ -45,10 +31,6 @@ export interface PurchaseItemPayload {
   kuantitas: number;
   hargaSatuan: number;
   keterangan: string;
-  jumlahKemasan?: number;
-  isiPerKemasan?: number;
-  satuanKemasan?: string;
-  hargaTotalBeliKemasan?: number;
 }
 
 interface SimplePurchaseItemFormProps {
@@ -114,7 +96,6 @@ const SafeNumericInput = React.forwardRef<
   );
 });
 
-const PACK_UNITS = ['pak', 'dus', 'karung', 'botol'];
 const BASE_UNITS = ['gram', 'kilogram', 'miligram', 'liter', 'milliliter', 'pcs', 'buah', 'biji', 'butir', 'lembar'];
 
 const SimplePurchaseItemForm: React.FC<SimplePurchaseItemFormProps> = ({ onCancel, onAdd }) => {
@@ -123,52 +104,19 @@ const SimplePurchaseItemForm: React.FC<SimplePurchaseItemFormProps> = ({ onCance
     satuan: '',
     kuantitas: '',
     totalBayar: '',
-    jumlahKemasan: '',
-    isiPerKemasan: '',
-    satuanKemasan: '',
-    hargaTotalBeliKemasan: '',
     keterangan: '',
   });
 
-  // Detail kemasan selalu ditampilkan
-
-  // Derived from packaging (kalau lengkap)
-  const qtyFromPackaging = useMemo(() => {
-    const q = toNumber(formData.jumlahKemasan) * toNumber(formData.isiPerKemasan);
-    return q > 0 ? q : 0;
-  }, [formData.jumlahKemasan, formData.isiPerKemasan]);
-
-  const totalPayFromPackaging = useMemo(() => {
-    const v = toNumber(formData.hargaTotalBeliKemasan);
-    return v > 0 ? v : 0;
-  }, [formData.hargaTotalBeliKemasan]);
-
-  // Harga per unit – urutan prioritas:
-  // 1) Kalau packaging valid → harga dari nota / total isi
-  // 2) Kalau user isi Total yang Dibeli + Total Bayar → totalBayar / kuantitas
   const computedUnitPrice = useMemo(() => {
-    if (qtyFromPackaging > 0 && totalPayFromPackaging > 0) {
-      return Math.round((totalPayFromPackaging / qtyFromPackaging) * 100) / 100;
-    }
     const qty = toNumber(formData.kuantitas);
     const pay = toNumber(formData.totalBayar);
     if (qty > 0 && pay > 0) {
       return Math.round((pay / qty) * 100) / 100;
     }
     return 0;
-  }, [qtyFromPackaging, totalPayFromPackaging, formData.kuantitas, formData.totalBayar]);
+  }, [formData.kuantitas, formData.totalBayar]);
 
-  // Total qty yang dipakai untuk ringkasan
-  const effectiveQty = useMemo(() => {
-    if (qtyFromPackaging > 0) return qtyFromPackaging;
-    return toNumber(formData.kuantitas);
-  }, [qtyFromPackaging, formData.kuantitas]);
-
-  // Total bayar yang dipakai untuk ringkasan
-  const effectivePay = useMemo(() => {
-    if (totalPayFromPackaging > 0) return totalPayFromPackaging;
-    return toNumber(formData.totalBayar);
-  }, [totalPayFromPackaging, formData.totalBayar]);
+  const effectiveQty = useMemo(() => toNumber(formData.kuantitas), [formData.kuantitas]);
 
   const subtotal = useMemo(() => effectiveQty * computedUnitPrice, [effectiveQty, computedUnitPrice]);
 
@@ -177,20 +125,6 @@ const SimplePurchaseItemForm: React.FC<SimplePurchaseItemFormProps> = ({ onCance
   const handleNumericChange = useCallback((field: keyof FormData, value: string) => {
     setFormData((prev) => (prev[field] === value ? prev : { ...prev, [field]: value }));
   }, []);
-
-  // Kalau packaging valid, sync nilai utama secara halus (tanpa bikin user bingung)
-  useEffect(() => {
-    if (qtyFromPackaging > 0) {
-      setFormData((prev) =>
-        prev.kuantitas === String(qtyFromPackaging) ? prev : { ...prev, kuantitas: String(qtyFromPackaging) }
-      );
-    }
-    if (totalPayFromPackaging > 0) {
-      setFormData((prev) =>
-        prev.totalBayar === String(totalPayFromPackaging) ? prev : { ...prev, totalBayar: String(totalPayFromPackaging) }
-      );
-    }
-  }, [qtyFromPackaging, totalPayFromPackaging]);
 
   // Debug mount/unmount
   useEffect(() => {
@@ -212,13 +146,6 @@ const SimplePurchaseItemForm: React.FC<SimplePurchaseItemFormProps> = ({ onCance
       kuantitas: effectiveQty,
       hargaSatuan: computedUnitPrice,
       keterangan: formData.keterangan,
-      jumlahKemasan:
-        formData.jumlahKemasan === '' ? undefined : toNumber(formData.jumlahKemasan),
-      isiPerKemasan:
-        formData.isiPerKemasan === '' ? undefined : toNumber(formData.isiPerKemasan),
-      hargaTotalBeliKemasan:
-        formData.hargaTotalBeliKemasan === '' ? undefined : toNumber(formData.hargaTotalBeliKemasan),
-      satuanKemasan: formData.satuanKemasan?.trim() || undefined,
     });
   };
 
@@ -231,9 +158,6 @@ const SimplePurchaseItemForm: React.FC<SimplePurchaseItemFormProps> = ({ onCance
   // refs
   const qtyRef = useRef<HTMLInputElement>(null);
   const payRef = useRef<HTMLInputElement>(null);
-  const packQtyRef = useRef<HTMLInputElement>(null);
-  const perPackRef = useRef<HTMLInputElement>(null);
-  const totalNotaRef = useRef<HTMLInputElement>(null);
 
   return (
     <Card className="border-dashed border-orange-200 bg-orange-50/30 backdrop-blur-sm">
@@ -244,15 +168,8 @@ const SimplePurchaseItemForm: React.FC<SimplePurchaseItemFormProps> = ({ onCance
               <Plus className="h-4 w-4 text-orange-600" />
             </div>
             <span className="text-lg">Tambah Item Baru</span>
-            <Badge
-              variant="outline"
-              className={
-                qtyFromPackaging > 0 && totalPayFromPackaging > 0
-                  ? 'bg-emerald-100 text-emerald-700 border-emerald-200'
-                  : 'bg-blue-100 text-blue-700 border-blue-200'
-              }
-            >
-              {qtyFromPackaging > 0 && totalPayFromPackaging > 0 ? 'Akurat 100%' : 'Otomatis dihitung'}
+            <Badge variant="outline" className="bg-blue-100 text-blue-700 border-blue-200">
+              Otomatis dihitung
             </Badge>
           </CardTitle>
           <Button
@@ -367,210 +284,6 @@ const SimplePurchaseItemForm: React.FC<SimplePurchaseItemFormProps> = ({ onCance
             </AlertDescription>
           </Alert>
         )}
-
-        {/* Detail pembelian */}
-        <div className="rounded-xl border border-gray-200 bg-white">
-          <div className="flex items-center gap-2 px-4 py-3">
-            <div className="w-6 h-6 bg-orange-100 rounded-md flex items-center justify-center">
-              <PackageIcon className="h-3.5 w-3.5 text-orange-600" />
-            </div>
-            <div className="font-medium text-gray-900">Detail Pembelian</div>
-            {qtyFromPackaging > 0 && totalPayFromPackaging > 0 && (
-              <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200">Akurat 100%</Badge>
-            )}
-          </div>
-          <div className="px-4 pb-4">
-            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
-              <div className="space-y-2">
-                <div className="flex items-center gap-1">
-                  <Label className="text-sm font-medium text-gray-700">Jumlah bungkus/dus</Label>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="h-4 w-4 text-gray-400" />
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-xs text-xs">
-                        Berapa banyak kemasan yang dibeli. Boleh desimal (mis. 1,5).
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-                <SafeNumericInput
-                  ref={packQtyRef}
-                  value={formData.jumlahKemasan ?? ''}
-                  inputMode="numeric"
-                  onBeforeInput={makeBeforeInputGuard(() => formData.jumlahKemasan ?? '', false)}
-                  onPaste={handlePasteGuard(false)}
-                  onChange={(e) => {
-                    handleNumericChange('jumlahKemasan', e.target.value);
-                    requestAnimationFrame(() => packQtyRef.current?.focus());
-                  }}
-                  placeholder="1"
-                  className="h-11 border-gray-200 focus:border-orange-500 focus:ring-orange-500/20"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label className="text-sm font-medium text-gray-700">Jenis Kemasan</Label>
-                <Select
-                  value={formData.satuanKemasan || ''}
-                  onValueChange={(value) => setFormData((prev) => ({ ...prev, satuanKemasan: value }))}
-                >
-                  <SelectTrigger className="h-11 border-gray-200 focus:border-orange-500 focus:ring-orange-500/20">
-                    <SelectValue placeholder="Pilih jenis" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PACK_UNITS.map((u) => (
-                      <SelectItem key={u} value={u}>
-                        {u}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex items-center gap-1">
-                  <Label className="text-sm font-medium text-gray-700">Isi per bungkus/dus</Label>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="h-4 w-4 text-gray-400" />
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-xs text-xs">
-                        Isi satu bungkus dalam satuan dasar bahan (gram/ml/pcs) sesuai master. Contoh: 1 bungkus = 500 gram.
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-                <div className="flex gap-2">
-                  <SafeNumericInput
-                    ref={perPackRef}
-                    value={formData.isiPerKemasan ?? ''}
-                    onBeforeInput={makeBeforeInputGuard(() => formData.isiPerKemasan ?? '', true)}
-                    onPaste={handlePasteGuard(true)}
-                    onChange={(e) => {
-                      handleNumericChange('isiPerKemasan', e.target.value);
-                      requestAnimationFrame(() => perPackRef.current?.focus());
-                    }}
-                    placeholder="500"
-                    className="h-11 border-gray-200 focus:border-orange-500 focus:ring-orange-500/20"
-                  />
-                  <div className="flex items-center px-2 bg-white border border-gray-200 rounded-md text-xs text-gray-600 min-w-[45px] justify-center">
-                    {formData.satuan || 'unit'}
-                  </div>
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex items-center gap-1">
-                  <Label className="text-sm font-medium text-gray-700">Total bayar (dari nota)</Label>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="h-4 w-4 text-gray-400" />
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-xs text-xs">
-                        Nominal yang dibayar untuk item ini setelah diskon. Sertakan ongkir/biaya lain jika ingin dihitung ke HPP.
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-                <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 text-sm">Rp</span>
-                  <SafeNumericInput
-                    ref={totalNotaRef}
-                    value={formData.hargaTotalBeliKemasan ?? ''}
-                    onBeforeInput={makeBeforeInputGuard(() => formData.hargaTotalBeliKemasan ?? '', true)}
-                    onPaste={handlePasteGuard(true)}
-                    onChange={(e) => {
-                      handleNumericChange('hargaTotalBeliKemasan', e.target.value);
-                      requestAnimationFrame(() => totalNotaRef.current?.focus());
-                    }}
-                    className="h-11 pl-8 border-gray-200 focus:border-orange-500 focus:ring-orange-500/20"
-                    placeholder="25000"
-                  />
-                </div>
-              </div>
-            </div>
-
-            {/* preview otomatis di dalam kartu */}
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mt-4">
-              <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
-                <div className="flex items-center gap-1 text-sm text-gray-600">
-                  <span>Total Item (otomatis)</span>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="h-4 w-4 text-gray-400" />
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-xs text-xs">
-                        Dihitung: jumlah bungkus × isi per bungkus.
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-                <div className="text-lg font-semibold">
-                  {qtyFromPackaging} {formData.satuan || 'unit'}
-                </div>
-              </div>
-              <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
-                <div className="flex items-center gap-1 text-sm text-gray-600">
-                  <span>Harga per {formData.satuan || 'unit'} (otomatis)</span>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="h-4 w-4 text-gray-400" />
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-xs text-xs">
-                        Dihitung: total bayar ÷ total item. Nilai ini dipakai untuk HPP.
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-                <div className="text-lg font-semibold text-orange-600">
-                  {formatCurrency(
-                    qtyFromPackaging > 0 && totalPayFromPackaging > 0
-                      ? totalPayFromPackaging / qtyFromPackaging
-                      : 0
-                  )}
-                </div>
-              </div>
-              <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
-                <div className="flex items-center gap-1 text-sm text-gray-600">
-                  <span>Harga per bungkus (otomatis)</span>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="h-4 w-4 text-gray-400" />
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-xs text-xs">
-                        Dihitung: total bayar ÷ jumlah bungkus.
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-                <div className="text-lg font-semibold">
-                  {formatCurrency(
-                    totalPayFromPackaging > 0 && toNumber(formData.jumlahKemasan) > 0
-                      ? totalPayFromPackaging / toNumber(formData.jumlahKemasan)
-                      : 0
-                  )}
-                </div>
-              </div>
-              <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
-                <div className="text-sm text-gray-600">Subtotal (otomatis)</div>
-                <div className="text-lg font-semibold">
-                  {formatCurrency(
-                    qtyFromPackaging > 0 && totalPayFromPackaging > 0
-                      ? (totalPayFromPackaging / qtyFromPackaging) * qtyFromPackaging
-                      : 0
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
 
         {/* Keterangan */}
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- simplify purchase item form by removing packaging/detail section and related state
- streamline purchase dialog item handling without packaging metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a32a1fcdb8832eaa969b27a644fcde