### PR TITLE
refactor: consolidate metode_perhitungan check

### DIFF
--- a/.bolt/supabase_discarded_migrations/20250629131631-8eba1192-f99a-4e85-9a4e-d39917da7207.sql
+++ b/.bolt/supabase_discarded_migrations/20250629131631-8eba1192-f99a-4e85-9a4e-d39917da7207.sql
@@ -38,7 +38,7 @@ CREATE TABLE public.purchases (
   items JSONB NOT NULL DEFAULT '[]',
   total_nilai NUMERIC NOT NULL DEFAULT 0,
   status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'completed', 'cancelled')),
-  metode_perhitungan TEXT NOT NULL DEFAULT 'FIFO' CHECK (metode_perhitungan IN ('FIFO', 'LIFO', 'Average')),
+  metode_perhitungan TEXT NOT NULL DEFAULT 'FIFO',
   catatan TEXT,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()

--- a/.bolt/supabase_discarded_migrations/20250701134935_autumn_grass.sql
+++ b/.bolt/supabase_discarded_migrations/20250701134935_autumn_grass.sql
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS public.purchases (
   items JSONB NOT NULL DEFAULT '[]',
   total_nilai NUMERIC NOT NULL DEFAULT 0,
   status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'completed', 'cancelled')),
-  metode_perhitungan TEXT NOT NULL DEFAULT 'FIFO' CHECK (metode_perhitungan IN ('FIFO', 'LIFO', 'Average')),
+  metode_perhitungan TEXT NOT NULL DEFAULT 'FIFO',
   catatan TEXT,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()

--- a/.bolt/supabase_discarded_migrations/20250701135136_summer_bar.sql
+++ b/.bolt/supabase_discarded_migrations/20250701135136_summer_bar.sql
@@ -137,8 +137,8 @@ BEGIN
     WHERE conname = 'purchases_metode_perhitungan_check' AND conrelid = 'purchases'::regclass
   ) THEN
     ALTER TABLE public.purchases 
-    ADD CONSTRAINT purchases_metode_perhitungan_check 
-    CHECK (metode_perhitungan IN ('FIFO', 'LIFO', 'Average'));
+    ADD CONSTRAINT purchases_metode_perhitungan_check
+    CHECK (metode_perhitungan IN ('FIFO', 'LIFO', 'AVERAGE'));
   END IF;
 END $$;
 


### PR DESCRIPTION
## Summary
- clean up duplicated `metode_perhitungan` constraints in legacy migrations
- enforce `FIFO`/`LIFO`/`AVERAGE` values via single check constraint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a3610b40c8832e9babb532fa5e385b