### PR TITLE
Refresh warehouse after purchase status update

### DIFF
--- a/src/components/purchase/hooks/usePurchaseStatus.ts
+++ b/src/components/purchase/hooks/usePurchaseStatus.ts
@@ -184,6 +184,15 @@ export const usePurchaseStatus = ({
       // Stok & WAC otomatis diurus trigger database saat status = 'completed',
       // serta disesuaikan saat edit/hapus setelah completed.
 
+      // Setelah status berhasil diubah, refresh data gudang agar stok terbaru ter-fetch
+      try {
+        await warehouseContext.refreshData();
+      } catch (refreshError) {
+        if (enableDebugLogs) {
+          logger.warn('Gagal me-refresh data gudang:', refreshError);
+        }
+      }
+
       onSuccess?.(
         `Status berhasil diubah menjadi "${getStatusDisplayText(newStatus)}". Stok gudang akan tersinkron otomatis.`
       );


### PR DESCRIPTION
## Summary
- refresh warehouse context after purchase status changes

## Testing
- `npm run lint` *(fails: 743 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b5312ae4832e89d01421d7f425d2