### PR TITLE
feat: listen for all purchase events

### DIFF
--- a/src/components/warehouse/context/WarehouseContext.tsx
+++ b/src/components/warehouse/context/WarehouseContext.tsx
@@ -265,14 +265,15 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({
       .on(
         'postgres_changes',
         {
-          event: 'UPDATE',
+          // Listen to all change events on purchases table to keep warehouse data in sync
+          event: '*',
           schema: 'public',
           table: 'purchases',
           filter: `user_id=eq.${user.id}`
         },
         (payload) => {
-          console.log('🔄 Purchase updated:', payload);
-          // Invalidate warehouse data when purchases are updated (status changes)
+          console.log('🔄 Purchase changed:', payload);
+          // Invalidate warehouse data when purchases are inserted, updated, or deleted
           queryClient.invalidateQueries({ queryKey: warehouseQueryKeys.list() });
         }
       )


### PR DESCRIPTION
## Summary
- listen to all Supabase purchase events and invalidate warehouse queries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 743 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bf718630832e88517648c18cb4a1