### PR TITLE
fix: guard navigator on server in WarehouseContext

### DIFF
--- a/src/components/warehouse/context/WarehouseContext.tsx
+++ b/src/components/warehouse/context/WarehouseContext.tsx
@@ -198,14 +198,18 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({
   const { addNotification } = useNotification();
 
   // ✅ FIXED: Live connection status tracking
-  const [isConnected, setIsConnected] = React.useState(navigator.onLine);
+  const [isConnected, setIsConnected] = React.useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true
+  );
   React.useEffect(() => {
+    if (typeof navigator === 'undefined') return;
+
     const handleOnline = () => setIsConnected(true);
     const handleOffline = () => setIsConnected(false);
-    
+
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
-    
+
     return () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
@@ -242,6 +246,7 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({
 
   // ✅ NEW: Real-time subscription for warehouse updates
   useEffect(() => {
+    if (typeof navigator === 'undefined') return;
     if (!user?.id) return;
 
     console.log('🔄 Setting up real-time subscription for user:', user.id);
@@ -587,6 +592,7 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({
 
   // ✅ DEBUG: Log context state changes
   React.useEffect(() => {
+    if (typeof navigator === 'undefined') return;
     logger.debug(`[${providerId.current}] 📊 Context state:`, {
       bahanBakuCount: bahanBaku.length,
       loading,


### PR DESCRIPTION
## Summary
- safely read navigator to detect connectivity
- skip effect hooks when navigator is unavailable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 743 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bf74afdc832eb758db72dca7a955