### PR TITLE
Generate UUIDs for newly added purchase items

### DIFF
--- a/src/components/purchase/components/PurchaseDialog.tsx
+++ b/src/components/purchase/components/PurchaseDialog.tsx
@@ -334,9 +334,9 @@ const PurchaseDialog: React.FC<PurchaseDialogProps> = ({
       if (effectiveQty <= 0) return toast.error('Total yang dibeli harus > 0');
       if (computedUnitPrice <= 0) return toast.error('Tidak bisa menghitung harga per unit');
 
-      // For new items, we'll use null for bahanBakuId since it doesn't exist yet
+      // For new items, generate a temporary ID since no warehouse item exists yet
       const purchaseItem: PurchaseItem = {
-        bahanBakuId: null,
+        bahanBakuId: generateUUID(),
         nama: newItemFormData.nama,
         satuan: newItemFormData.satuan,
         kuantitas: effectiveQty,

--- a/src/components/purchase/components/dialogs/NewItemForm.tsx
+++ b/src/components/purchase/components/dialogs/NewItemForm.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Plus, Package, Calculator } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatCurrency } from '@/utils/formatUtils';
+import { generateUUID } from '@/utils/uuid';
 import { SafeNumericInput } from './SafeNumericInput';
 import type { BahanBakuFrontend } from '@/components/warehouse/types';
 import type { PurchaseItem } from '../../types/purchase.types';
@@ -122,6 +123,7 @@ export const NewItemForm: React.FC<NewItemFormProps> = ({
       }
 
       const purchaseItem: PurchaseItem = {
+        bahanBakuId: generateUUID(),
         nama: formData.nama,
         satuan: formData.satuan,
         kuantitas: effectiveQty,


### PR DESCRIPTION
## Summary
- assign a generated UUID to `bahanBakuId` when adding new purchase items without a warehouse match
- generate and pass a UUID in `NewItemForm` when creating brand-new items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 751 problems (656 errors, 95 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a4369d66dc832eb7c675329d742b85