### PR TITLE
feat: support custom IDs for new warehouse items

### DIFF
--- a/src/components/purchase/context/PurchaseContext.tsx
+++ b/src/components/purchase/context/PurchaseContext.tsx
@@ -99,7 +99,7 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const { addNotification } = useNotification();
   // Add defensive check for useBahanBaku
   let bahanBaku = [];
-  let addBahanBaku = async () => false;
+  let addBahanBaku = async (_: any) => false;
   try {
     const warehouseContext = useBahanBaku();
     bahanBaku = warehouseContext?.bahanBaku || [];
@@ -203,9 +203,10 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           const exists = bahanBaku?.some((bb) => bb.id === item.bahanBakuId);
           if (!exists) {
             await addBahanBaku({
+              id: item.bahanBakuId,
               nama: item.nama,
               kategori: 'Lainnya',
-              stok: 0,
+              stok: item.kuantitas,
               minimum: 0,
               satuan: item.satuan || '-',
               harga: item.hargaSatuan || 0,

--- a/src/components/warehouse/context/WarehouseContext.tsx
+++ b/src/components/warehouse/context/WarehouseContext.tsx
@@ -38,7 +38,9 @@ interface WarehouseContextType {
   lastUpdated?: Date;
   
   // Actions
-  addBahanBaku: (bahan: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'>) => Promise<boolean>;
+  addBahanBaku: (
+    bahan: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'> & { id?: string }
+  ) => Promise<boolean>;
   updateBahanBaku: (id: string, updates: Partial<BahanBakuFrontend>) => Promise<boolean>;
   deleteBahanBaku: (id: string) => Promise<boolean>;
   bulkDeleteBahanBaku: (ids: string[]) => Promise<boolean>;
@@ -100,7 +102,10 @@ const fetchWarehouseData = async (userId?: string): Promise<BahanBakuFrontend[]>
   }
 };
 
-const createWarehouseItem = async (item: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'>, userId?: string): Promise<boolean> => {
+const createWarehouseItem = async (
+  item: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'> & { id?: string },
+  userId?: string
+): Promise<boolean> => {
   try {
     logger.debug('🔄 createWarehouseItem called:', { item, userId });
     
@@ -292,8 +297,9 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({
 
   // ✅ FIXED: Mutations with proper error handling and return values
   const createMutation = useMutation({
-    mutationFn: (item: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'>) => 
-      createWarehouseItem(item, user?.id),
+    mutationFn: (
+      item: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'> & { id?: string }
+    ) => createWarehouseItem(item, user?.id),
     onSuccess: (success, item) => {
       if (success) {
         queryClient.invalidateQueries({ queryKey: warehouseQueryKeys.list() });
@@ -367,7 +373,10 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({
   });
 
   // ✅ FIXED: CRUD operations with proper async handling (stabilized with useCallback)
-  const addBahanBaku = React.useCallback(async (bahan: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'>): Promise<boolean> => {
+  const addBahanBaku = React.useCallback(
+    async (
+      bahan: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'> & { id?: string }
+    ): Promise<boolean> => {
     try {
       logger.debug(`[${providerId.current}] 🎯 addBahanBaku called:`, bahan);
       const result = await createMutation.mutateAsync(bahan);

--- a/src/components/warehouse/services/warehouseApi.ts
+++ b/src/components/warehouse/services/warehouseApi.ts
@@ -40,6 +40,7 @@ const transformToFrontend = (dbItem: BahanBaku): BahanBakuFrontend => {
 // Transform FE -> DB (❗️tanpa field kemasan)
 const transformToDatabase = (frontendItem: Partial<BahanBakuFrontend>, userId?: string): Partial<BahanBaku> => {
   const dbItem: Partial<BahanBaku> = {
+    id: frontendItem.id,
     nama: frontendItem.nama,
     kategori: frontendItem.kategori,
     stok: frontendItem.stok,
@@ -81,7 +82,9 @@ class CrudService {
     }
   }
 
-  async addBahanBaku(bahan: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'>): Promise<boolean> {
+  async addBahanBaku(
+    bahan: Omit<BahanBakuFrontend, 'id' | 'createdAt' | 'updatedAt' | 'userId'> & { id?: string }
+  ): Promise<boolean> {
     try {
       const dbData = transformToDatabase(bahan, this.config.userId);
       const { error } = await supabase.from('bahan_baku').insert(dbData);


### PR DESCRIPTION
## Summary
- allow addBahanBaku to accept optional id and pass through to DB
- update warehouse context and purchase flow to supply existing bahanBakuId and purchased stock/price

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 752 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a436a2d6cc832eaebdf5321c6f025b