### PR TITLE
Allow purchases without suppliers

### DIFF
--- a/src/components/purchase/PurchasePage.tsx
+++ b/src/components/purchase/PurchasePage.tsx
@@ -141,15 +141,14 @@ const PurchasePageContent: React.FC<PurchasePageProps> = ({ className = '' }) =>
   const dialogActions = useMemo(() => ({
     purchase: {
       openAdd: () => {
-        if (validatePrerequisites()) {
-          setAppState(prev => ({
-            ...prev,
-            dialogs: {
-              ...prev.dialogs,
-              purchase: { isOpen: true, editing: null, mode: 'create' }
-            }
-          }));
-        }
+        validatePrerequisites();
+        setAppState(prev => ({
+          ...prev,
+          dialogs: {
+            ...prev.dialogs,
+            purchase: { isOpen: true, editing: null, mode: 'create' }
+          }
+        }));
       },
       openEdit: (purchase: any) => {
         // edit selalu diperbolehkan (stok/WAC diurus trigger DB)

--- a/src/components/purchase/components/EmptyState.tsx
+++ b/src/components/purchase/components/EmptyState.tsx
@@ -1,9 +1,10 @@
 // src/components/purchase/components/EmptyState.tsx
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { ShoppingCart, Plus, Users } from 'lucide-react';
+import { SupplierDialog } from '@/components/supplier';
 
 interface EmptyStateProps {
   onAddPurchase: () => void;
@@ -16,7 +17,7 @@ const EmptyState: React.FC<EmptyStateProps> = ({
   hasSuppliers,
   className = '',
 }) => {
-  const canCreatePurchase = hasSuppliers;
+  const [supplierDialogOpen, setSupplierDialogOpen] = useState(false);
 
   return (
     <Card className={`p-12 text-center ${className}`}>
@@ -26,63 +27,46 @@ const EmptyState: React.FC<EmptyStateProps> = ({
           <ShoppingCart className="h-8 w-8 text-gray-400" />
         </div>
 
-        {/* Content based on state */}
-        {canCreatePurchase ? (
-          <>
-            {/* Ready to create purchases */}
-            <h3 className="text-lg font-semibold text-gray-900 mb-3">
-              Belum Ada Pembelian
-            </h3>
-            <p className="text-gray-500 mb-6">
-              Mulai dengan membuat pembelian pertama dari supplier Anda. 
-              Semua transaksi pembelian akan muncul di sini.
-            </p>
-            <Button
-              onClick={onAddPurchase}
-              className="inline-flex items-center gap-2"
-            >
-              <Plus className="h-4 w-4" />
-              Buat Pembelian Pertama
-            </Button>
-          </>
-        ) : (
-          <>
-            {/* Missing prerequisites */}
-            <h3 className="text-lg font-semibold text-gray-900 mb-3">
-              Siapkan Data Dasar Dulu
-            </h3>
-            <p className="text-gray-500 mb-6">
-              Untuk membuat pembelian, Anda perlu menyiapkan data supplier terlebih dahulu.
-            </p>
+        {/* Main content */}
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">
+          Belum Ada Pembelian
+        </h3>
+        <p className="text-gray-500 mb-6">
+          Mulai dengan membuat pembelian pertama dari supplier Anda.
+          Semua transaksi pembelian akan muncul di sini.
+        </p>
+        <Button onClick={onAddPurchase} className="inline-flex items-center gap-2">
+          <Plus className="h-4 w-4" />
+          Buat Pembelian Pertama
+        </Button>
 
-            {/* Missing data indicators */}
-            <div className="space-y-3 mb-6">
-              {!hasSuppliers && (
-                <div className="flex items-center justify-center gap-2 text-sm text-amber-600 bg-amber-50 p-3 rounded-lg">
-                  <Users className="h-4 w-4" />
-                  <span>Data supplier belum ada</span>
-                </div>
-              )}
+        {!hasSuppliers && (
+          <>
+            {/* Warning about missing suppliers */}
+            <div className="space-y-3 my-6">
+              <div className="flex items-center justify-center gap-2 text-sm text-amber-600 bg-amber-50 p-3 rounded-lg">
+                <Users className="h-4 w-4" />
+                <span>Data supplier belum ada</span>
+              </div>
             </div>
 
             {/* Action buttons */}
             <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              {!hasSuppliers && (
-                <Button
-                  variant="outline"
-                  onClick={() => window.location.href = '/supplier'}
-                  className="inline-flex items-center gap-2"
-                >
-                  <Users className="h-4 w-4" />
-                  Tambah Supplier
-                </Button>
-              )}
+              <Button
+                variant="outline"
+                onClick={() => setSupplierDialogOpen(true)}
+                className="inline-flex items-center gap-2"
+              >
+                <Users className="h-4 w-4" />
+                Tambah Supplier
+              </Button>
             </div>
 
-            {/* Helper text */}
-            <div className="mt-6 text-xs text-gray-400">
-              Setelah data supplier siap, Anda bisa mulai membuat pembelian
-            </div>
+            <SupplierDialog
+              open={supplierDialogOpen}
+              onOpenChange={setSupplierDialogOpen}
+              supplier={null}
+            />
           </>
         )}
       </div>

--- a/src/components/purchase/context/PurchaseContext.tsx
+++ b/src/components/purchase/context/PurchaseContext.tsx
@@ -464,7 +464,9 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   // Prasyarat data (buat tombol "Tambah")
   const validatePrerequisites = useCallback(() => {
     const hasSuppliers = (suppliers?.length || 0) > 0;
-    if (!hasSuppliers) { toast.error('Mohon tambahkan data supplier terlebih dahulu'); return false; }
+    if (!hasSuppliers) {
+      toast.warning('Belum ada data supplier. Kamu bisa menambahkannya nanti.');
+    }
     return true;
   }, [suppliers?.length]);
 

--- a/src/components/purchase/hooks/usePurchaseCore.ts
+++ b/src/components/purchase/hooks/usePurchaseCore.ts
@@ -57,9 +57,9 @@ export const usePurchaseCore = ({
       return validationRef.current.validation;
     }
     const calculated = {
-      hasSuppliers: suppliersLength > 0,
-      hasMinimumData: suppliersLength > 0,
-      missingDataTypes: !suppliersLength ? ['suppliers'] : []
+      hasSuppliers: true,
+      hasMinimumData: true,
+      missingDataTypes: suppliersLength > 0 ? [] : ['suppliers']
     };
     validationRef.current = { suppliersLength, validation: calculated };
     return calculated;
@@ -227,9 +227,11 @@ export const usePurchaseCore = ({
     // Validation / prerequisites
     validation,
     validatePrerequisites: useCallback((): boolean => {
-      if (!validation.hasSuppliers) { toast.error('Mohon tambahkan data supplier terlebih dahulu'); return false; }
+      if (!suppliers?.length) {
+        toast.warning('Belum ada data supplier. Kamu bisa menambahkannya nanti.');
+      }
       return true;
-    }, [validation.hasSuppliers]),
+    }, [suppliers?.length]),
 
     // Status operations
     canEdit,


### PR DESCRIPTION
## Summary
- Warn instead of blocking when supplier list is empty
- Permit purchase validation without suppliers and show supplier dialog in empty state
- Always open purchase dialog regardless of supplier presence

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 752 problems (657 errors, 95 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a43a5be7fc832ea5c17c93ebeb3dbd