### PR TITLE
Return Supplier object from add flow

### DIFF
--- a/src/components/supplier/SupplierDialog.tsx
+++ b/src/components/supplier/SupplierDialog.tsx
@@ -15,7 +15,7 @@ interface SupplierDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   supplier: Supplier | null;
-  onSuccess?: () => void;
+  onSuccess?: (supplier: Supplier) => void;
 }
 
 const SupplierDialog: React.FC<SupplierDialogProps> = ({
@@ -24,9 +24,9 @@ const SupplierDialog: React.FC<SupplierDialogProps> = ({
   supplier,
   onSuccess
 }) => {
-  const handleSuccess = () => {
+  const handleSuccess = (savedSupplier: Supplier) => {
     onOpenChange(false);
-    onSuccess?.();
+    onSuccess?.(savedSupplier);
   };
 
   const handleCancel = () => {

--- a/src/components/supplier/SupplierForm.tsx
+++ b/src/components/supplier/SupplierForm.tsx
@@ -11,7 +11,7 @@ import type { Supplier } from '@/types/supplier';
 
 interface SupplierFormProps {
   supplier: Supplier | null;
-  onSuccess?: () => void;
+  onSuccess?: (supplier: Supplier) => void;
   onCancel?: () => void;
   className?: string;
 }

--- a/src/components/supplier/SupplierManagement.tsx
+++ b/src/components/supplier/SupplierManagement.tsx
@@ -60,7 +60,7 @@ const SupplierManagement: React.FC = () => {
     setIsDialogOpen(true);
   };
 
-  const handleDialogClose = () => {
+  const handleDialogClose = (newSupplier?: Supplier) => {
     setIsDialogOpen(false);
     setEditingSupplier(null);
     setSelectedSupplierIds(prev => prev.filter(id => id !== (editingSupplier?.id || '')));

--- a/src/contexts/SupplierContext.tsx
+++ b/src/contexts/SupplierContext.tsx
@@ -52,7 +52,7 @@ interface SupplierContextType {
   error: string | null;
   
   // Actions
-  addSupplier: (supplier: Omit<Supplier, 'id' | 'createdAt' | 'updatedAt' | 'userId'>) => Promise<boolean>;
+  addSupplier: (supplier: Omit<Supplier, 'id' | 'createdAt' | 'updatedAt' | 'userId'>) => Promise<Supplier | null>;
   updateSupplier: (id: string, supplier: Partial<Omit<Supplier, 'id' | 'userId'>>) => Promise<boolean>;
   deleteSupplier: (id: string) => Promise<boolean>;
   
@@ -476,17 +476,17 @@ export const SupplierProvider: React.FC<{ children: ReactNode }> = ({ children }
 
   const addSupplier = useCallback(async (
     supplierData: Omit<Supplier, 'id' | 'createdAt' | 'updatedAt' | 'userId'>
-  ): Promise<boolean> => {
+  ): Promise<Supplier | null> => {
     if (!user) {
       toast.error('Anda harus login untuk menambahkan supplier');
-      return false;
+      return null;
     }
 
     try {
-      await addMutation.mutateAsync(supplierData);
-      return true;
+      const newSupplier = await addMutation.mutateAsync(supplierData);
+      return newSupplier;
     } catch (error) {
-      return false;
+      return null;
     }
   }, [user, addMutation]);
 

--- a/src/types/supplier.ts
+++ b/src/types/supplier.ts
@@ -96,7 +96,7 @@ export interface SupplierTableProps {
 
 export interface SupplierFormProps {
   supplier: Supplier | null;
-  onSuccess?: () => void;
+  onSuccess?: (supplier: Supplier) => void;
   onCancel?: () => void;
   className?: string;
 }
@@ -105,7 +105,7 @@ export interface SupplierDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   supplier: Supplier | null;
-  onSuccess?: () => void;
+  onSuccess?: (supplier: Supplier) => void;
 }
 
 export interface SupplierFiltersProps {
@@ -131,7 +131,7 @@ export interface BulkActionsProps {
 export interface UseSupplierFormReturn {
   formData: SupplierFormData;
   formErrors: Record<string, string>;
-  handleSubmit: () => Promise<boolean>;
+  handleSubmit: () => Promise<Supplier | null>;
   resetForm: () => void;
   updateField: (field: keyof SupplierFormData, value: string) => void;
   isEditing: boolean;


### PR DESCRIPTION
## Summary
- have `addSupplier` return the created Supplier instead of a boolean
- propagate the created Supplier through form hook and dialog success callbacks
- update types and management component for new `onSuccess` signature

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, no-require-imports, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68a43a4ac60c832e8a8c28c293ade924