### PR TITLE
Fix purchase delete id handling

### DIFF
--- a/src/components/purchase/components/table/ActionButtons.tsx
+++ b/src/components/purchase/components/table/ActionButtons.tsx
@@ -1,13 +1,13 @@
 // src/components/purchase/components/table/ActionButtons.tsx
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Edit3, Trash2, Eye } from 'lucide-react';
+import { Edit3, Trash2 } from 'lucide-react';
 import { Purchase } from '../../types/purchase.types';
 
 interface ActionButtonsProps {
   purchase: Purchase;
   onEdit: (purchase: Purchase) => void;
-  onDelete: (id: string) => void;
+  onDelete: (purchase: Purchase) => void;
 }
 
 export const ActionButtons: React.FC<ActionButtonsProps> = ({
@@ -29,7 +29,7 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
       <Button
         variant="outline"
         size="sm"
-        onClick={() => onDelete(purchase.id)}
+        onClick={() => onDelete(purchase)}
         className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
         title="Hapus"
       >

--- a/src/components/purchase/components/table/PurchaseTableRow.tsx
+++ b/src/components/purchase/components/table/PurchaseTableRow.tsx
@@ -16,7 +16,7 @@ interface PurchaseTableRowProps {
   onEditStatus: (id: string) => void;
   onStatusChange: (purchaseId: string, newStatus: string) => Promise<void>;
   onEdit: (purchase: Purchase) => void;
-  onDelete: (id: string) => void;
+  onDelete: (purchase: Purchase) => void;
   getSupplierName: (id: string) => string;
 }
 
@@ -101,8 +101,8 @@ export const PurchaseTableRow: React.FC<PurchaseTableRowProps> = ({
       </TableCell>
 
       <TableCell>
-        <ActionButtons 
-          purchase={purchase} 
+        <ActionButtons
+          purchase={purchase}
           onEdit={onEdit}
           onDelete={onDelete}
         />


### PR DESCRIPTION
## Summary
- Ensure ActionButtons and PurchaseTableRow pass purchase objects to delete handler
- Prevent undefined IDs causing delete failures

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 766 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a440161934832e9f54d256028a893a