### PR TITLE
fix: resolve supplier names

### DIFF
--- a/src/components/purchase/context/PurchaseContext.tsx
+++ b/src/components/purchase/context/PurchaseContext.tsx
@@ -109,10 +109,12 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   }
   const getSupplierName = useCallback((supplierId: string): string => {
     try {
-      const s = suppliers?.find((x: any) => x.id === supplierId);
-      return s?.nama || 'Supplier';
+      const s = suppliers?.find(
+        (x: any) => x.id === supplierId || x.nama === supplierId
+      );
+      return s?.nama || supplierId || 'Supplier';
     } catch {
-      return 'Supplier';
+      return supplierId || 'Supplier';
     }
   }, [suppliers]);
 

--- a/src/components/purchase/hooks/usePurchaseTable.ts
+++ b/src/components/purchase/hooks/usePurchaseTable.ts
@@ -193,7 +193,9 @@ export const usePurchaseTable = ({
 
   // Helper function to get supplier name
   const getSupplierName = useCallback((supplierId: string): string => {
-    const supplier = suppliers.find(s => s.id === supplierId);
+    const supplier = suppliers.find(
+      s => s.id === supplierId || s.nama === supplierId
+    );
     return supplier?.nama || supplierId;
   }, [suppliers]);
 

--- a/src/components/purchase/hooks/usePurchaseTableState.ts
+++ b/src/components/purchase/hooks/usePurchaseTableState.ts
@@ -71,8 +71,10 @@ export const usePurchaseTableState = ({ initialPurchases, suppliers }: UsePurcha
 
   // Get supplier name
   const getSupplierName = useCallback((supplierId: string): string => {
-    const supplier = suppliers.find(s => s.id === supplierId);
-    return supplier ? supplier.nama : 'Supplier Tidak Dikenal';
+    const supplier = suppliers.find(
+      s => s.id === supplierId || s.nama === supplierId
+    );
+    return supplier ? supplier.nama : supplierId || 'Supplier Tidak Dikenal';
   }, [suppliers]);
 
   return {

--- a/src/components/warehouse/services/warehouseApi.ts
+++ b/src/components/warehouse/services/warehouseApi.ts
@@ -75,7 +75,28 @@ class CrudService {
       const { data, error } = await query.order('nama', { ascending: true });
       if (error) throw error;
 
-      return (data || []).map(transformToFrontend);
+      // Map supplier IDs to names for display
+      const supplierIds = Array.from(
+        new Set((data || []).map(item => item.supplier).filter(Boolean))
+      );
+      let supplierMap: Record<string, string> = {};
+      if (supplierIds.length > 0) {
+        const { data: supplierData } = await supabase
+          .from('suppliers')
+          .select('id, nama')
+          .in('id', supplierIds);
+        supplierMap = Object.fromEntries(
+          (supplierData || []).map((s: any) => [s.id, s.nama])
+        );
+      }
+
+      return (data || []).map((item: any) => {
+        const transformed = transformToFrontend(item);
+        return {
+          ...transformed,
+          supplier: supplierMap[item.supplier] || item.supplier,
+        };
+      });
     } catch (error: any) {
       this.handleError('Fetch failed', error);
       return [];

--- a/src/utils/purchaseHelpers.ts
+++ b/src/utils/purchaseHelpers.ts
@@ -274,8 +274,10 @@ export const getSupplierName = (
   supplierId: string,
   suppliers: Array<{ id: string; nama: string }>
 ): string => {
-  const supplier = suppliers.find(s => s.id === supplierId);
-  return supplier?.nama || 'Unknown Supplier';
+  const supplier = suppliers.find(
+    s => s.id === supplierId || s.nama === supplierId
+  );
+  return supplier?.nama || supplierId || 'Unknown Supplier';
 };
 
 export const formatItemsDisplay = (items: PurchaseItem[]): string => {


### PR DESCRIPTION
## Summary
- map supplier IDs to supplier names when fetching warehouse items
- correctly resolve supplier name from ID or name in purchase helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 766 problems (670 errors, 96 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a446e71588832ea2e072c85420e2e2