### PR TITLE
feat: import pembelian bahan baku

### DIFF
--- a/src/components/purchase/components/ImportButton.tsx
+++ b/src/components/purchase/components/ImportButton.tsx
@@ -1,0 +1,54 @@
+import React, { useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Upload } from 'lucide-react';
+import { toast } from 'sonner';
+import { usePurchase } from '../context/PurchaseContext';
+import { parsePurchaseCSV } from '../utils/purchaseImport';
+
+const ImportButton: React.FC = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { addPurchase, setBulkProcessing } = usePurchase();
+
+  const handleFile = async (file: File) => {
+    try {
+      const purchases = await parsePurchaseCSV(file);
+      if (!purchases.length) {
+        toast.error('Tidak ada data yang dapat diimport');
+        return;
+      }
+      setBulkProcessing(true);
+      let success = 0;
+      for (const p of purchases) {
+        const ok = await addPurchase(p);
+        if (ok) success++;
+      }
+      setBulkProcessing(false);
+      toast.success(`${success} pembelian berhasil diimport`);
+    } catch (err: any) {
+      toast.error(err.message || 'Gagal mengimpor file');
+    }
+  };
+
+  return (
+    <>
+      <input
+        type="file"
+        accept=".csv"
+        ref={inputRef}
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleFile(file);
+          e.target.value = '';
+        }}
+      />
+      <Button variant="secondary" onClick={() => inputRef.current?.click()} className="flex items-center gap-2">
+        <Upload className="h-4 w-4" />
+        Import
+      </Button>
+    </>
+  );
+};
+
+export default ImportButton;
+

--- a/src/components/purchase/components/PurchaseHeader.tsx
+++ b/src/components/purchase/components/PurchaseHeader.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { formatCurrency } from '@/utils/formatUtils';
 import { PurchaseHeaderProps } from '../types/purchase.types';
+import ImportButton from './ImportButton';
 
 const PurchaseHeader: React.FC<PurchaseHeaderProps> = ({
   totalPurchases,
@@ -41,7 +42,7 @@ const PurchaseHeader: React.FC<PurchaseHeaderProps> = ({
           
           {/* Right actions */}
           <div className="flex flex-col sm:flex-row gap-3 w-full lg:w-auto">
-            {/* Hanya 1 tombol: Tambah dari Nota */}
+            <ImportButton />
             <Button
               onClick={() => onAddPurchase('packaging')} // Pastikan tipe 'packaging' sesuai dengan yang diharapkan
               className="flex items-center justify-center gap-2 px-6 py-3 bg-white text-orange-600 font-semibold rounded-lg border hover:bg-gray-100 transition-colors duration-200"
@@ -49,7 +50,6 @@ const PurchaseHeader: React.FC<PurchaseHeaderProps> = ({
               <FileText className="h-5 w-5" />
               Tambah Pembelian
             </Button>
-
           </div>
         </div>
 

--- a/src/components/purchase/utils/purchaseImport.ts
+++ b/src/components/purchase/utils/purchaseImport.ts
@@ -1,0 +1,82 @@
+import type { Purchase, PurchaseItem } from '../types/purchase.types';
+
+export type ImportedPurchase = Omit<Purchase, 'id' | 'userId' | 'createdAt' | 'updatedAt'>;
+
+interface RawRow {
+  supplier: string;
+  tanggal: string;
+  nama: string;
+  kuantitas: number;
+  satuan: string;
+  harga: number;
+}
+
+/**
+ * Parse CSV file menjadi array pembelian.
+ * Format kolom yang didukung:
+ * supplier,tanggal,nama,kuantitas,satuan,harga
+ */
+export async function parsePurchaseCSV(file: File): Promise<ImportedPurchase[]> {
+  const text = await file.text();
+  const lines = text.split(/\r?\n/).filter((l) => l.trim());
+  if (lines.length < 2) return [];
+
+  const headers = lines[0].split(',').map((h) => h.trim().toLowerCase());
+  const getIndex = (name: string) => headers.indexOf(name);
+
+  const idxSupplier = getIndex('supplier');
+  const idxTanggal = getIndex('tanggal');
+  const idxNama = getIndex('nama');
+  const idxQty = getIndex('kuantitas');
+  const idxSatuan = getIndex('satuan');
+  const idxHarga = getIndex('harga');
+
+  if ([idxSupplier, idxTanggal, idxNama, idxQty, idxSatuan, idxHarga].some((i) => i === -1)) {
+    throw new Error('Kolom wajib tidak lengkap');
+  }
+
+  const rows: RawRow[] = lines.slice(1).map((line) => {
+    const values = line.split(',').map((v) => v.trim());
+    return {
+      supplier: values[idxSupplier] || '',
+      tanggal: values[idxTanggal] || '',
+      nama: values[idxNama] || '',
+      kuantitas: parseFloat(values[idxQty] || '0'),
+      satuan: values[idxSatuan] || '',
+      harga: parseFloat(values[idxHarga] || '0'),
+    };
+  });
+
+  const grouped = new Map<string, ImportedPurchase>();
+
+  rows.forEach((r) => {
+    if (!r.supplier || !r.tanggal || !r.nama) return;
+    const key = `${r.supplier}-${r.tanggal}`;
+    let purchase = grouped.get(key);
+    if (!purchase) {
+      purchase = {
+        supplier: r.supplier,
+        tanggal: new Date(r.tanggal),
+        items: [],
+        totalNilai: 0,
+        status: 'pending',
+        metodePerhitungan: 'AVERAGE',
+      };
+      grouped.set(key, purchase);
+    }
+
+    const item: PurchaseItem = {
+      bahanBakuId: '',
+      nama: r.nama,
+      kuantitas: r.kuantitas,
+      satuan: r.satuan,
+      hargaSatuan: r.harga,
+      subtotal: r.kuantitas * r.harga,
+    };
+    purchase.items.push(item);
+    purchase.totalNilai += item.subtotal;
+  });
+
+  return Array.from(grouped.values());
+}
+


### PR DESCRIPTION
## Ringkasan
- tambah tombol `Import` di header pembelian
- dukung impor CSV untuk membuat pembelian bulk
- sediakan utilitas parser CSV pembelian

## Testing
- `npm test` (gagal: Missing script: "test")
- `npm run lint` (gagal: 767 problems (671 errors, 96 warnings))

------
https://chatgpt.com/codex/tasks/task_e_68a4499dcf24832eb771b87109370b89