### PR TITLE
Perbaiki deduplikasi notifikasi dengan pembersihan periodik

### DIFF
--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -323,6 +323,11 @@ export const NotificationProvider: React.FC<{ children: ReactNode }> = ({ childr
     });
   }, []);
 
+  useEffect(() => {
+    const interval = setInterval(cleanupExpiredNotifications, DUPLICATE_THRESHOLD);
+    return () => clearInterval(interval);
+  }, [cleanupExpiredNotifications, DUPLICATE_THRESHOLD]);
+
   // ===========================================
   // ✅ COMPUTED VALUES
   // ===========================================


### PR DESCRIPTION
## Ringkasan
- tambahkan efek berkala untuk membersihkan cache deduplikasi notifikasi

## Pengujian
- `npm run lint` (gagal: ✖ 767 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a451253e64832e8f2cca7633dca88a