### PR TITLE
feat: mode gelap netral

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,10 +67,10 @@ const App = () => {
           <Suspense fallback={<AppLoader />}>
             <AppRouter />
           </Suspense>
-          
+
           {/* ✅ Dev tools only in development */}
           {import.meta.env.DEV && (
-            <ReactQueryDevtools 
+            <ReactQueryDevtools
               initialIsOpen={false} 
               position="bottom-right"
               toggleButtonProps={{

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -59,6 +59,7 @@ import { useProfitAnalysis } from "@/components/profitAnalysis";
 
 // --- Import Fungsi Export ---
 import { exportAllDataToExcel } from "@/utils/exportUtils";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 export function AppSidebar() {
   const location = useLocation();
@@ -303,6 +304,15 @@ export function AppSidebar() {
       {/* ✅ Footer with delayed animation */}
       <SidebarFooter className="p-2 border-t mt-auto opacity-100 transition-all duration-300 delay-200 group-data-[collapsible=icon]:px-0">
         <SidebarMenu className="space-y-1">
+          {/* Theme Toggle - only for desktop */}
+          <SidebarMenuItem className="hidden md:block transition-all duration-200 ease-in-out">
+            <SidebarMenuButton asChild>
+              <ThemeToggle className="w-full">
+                <span>Tema</span>
+              </ThemeToggle>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+
           {/* Export Button */}
           <SidebarMenuItem className="transition-all duration-200 ease-in-out">
             {renderActionButton(

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { useTheme } from "next-themes"
+import { Sun, Moon } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export const ThemeToggle = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({ className, children, ...props }, ref) => {
+    const { theme, setTheme } = useTheme()
+    const [mounted, setMounted] = React.useState(false)
+
+    React.useEffect(() => setMounted(true), [])
+    if (!mounted) return null
+
+    const isDark = theme === "dark"
+
+    return (
+      <button
+        ref={ref}
+        onClick={() => setTheme(isDark ? "light" : "dark")}
+        className={cn("flex items-center gap-2 rounded p-2", className)}
+        {...props}
+      >
+        {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+        {children ? children : <span className="sr-only">Toggle tema</span>}
+      </button>
+    )
+  }
+)
+
+ThemeToggle.displayName = "ThemeToggle"

--- a/src/index.css
+++ b/src/index.css
@@ -72,41 +72,42 @@ All colors MUST be HSL.
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    --background: 0 0% 10%;
+    --foreground: 0 0% 90%;
 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
+    --card: 0 0% 10%;
+    --card-foreground: 0 0% 90%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 0 0% 10%;
+    --popover-foreground: 0 0% 90%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 0 0% 40%;
+    --primary-foreground: 0 0% 90%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 0 0% 40%;
+    --secondary-foreground: 0 0% 90%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 0 0% 40%;
+    --muted-foreground: 0 0% 90%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 0 0% 40%;
+    --accent-foreground: 0 0% 90%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 0% 40%;
+    --destructive-foreground: 0 0% 90%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --border: 0 0% 40%;
+    --input: 0 0% 40%;
+    --ring: 0 0% 40%;
+
+    --sidebar-background: 0 0% 10%;
+    --sidebar-foreground: 0 0% 90%;
+    --sidebar-primary: 0 0% 40%;
+    --sidebar-primary-foreground: 0 0% 90%;
+    --sidebar-accent: 0 0% 40%;
+    --sidebar-accent-foreground: 0 0% 90%;
+    --sidebar-border: 0 0% 40%;
+    --sidebar-ring: 0 0% 40%;
   }
 }
 
@@ -117,5 +118,26 @@ All colors MUST be HSL.
 
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer base {
+  .dark [class*="bg-white"],
+  .dark [class*="bg-gray-50"],
+  .dark [class*="bg-gray-100"] {
+    background-color: hsl(var(--card)) !important;
+  }
+
+  .dark [class*="text-black"],
+  .dark [class*="text-gray-800"],
+  .dark [class*="text-gray-900"],
+  .dark [class*="text-gray-700"] {
+    color: hsl(var(--foreground)) !important;
+  }
+
+  .dark [class*="border-gray-100"],
+  .dark [class*="border-gray-200"],
+  .dark [class*="border-gray-300"] {
+    border-color: hsl(var(--border)) !important;
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter as Router } from "react-router-dom";
+import { ThemeProvider } from "next-themes";
 import App from "./App.tsx";
 import "./index.css";
 import ErrorBoundary from "@/components/dashboard/ErrorBoundary";
@@ -100,9 +101,11 @@ logger.debug("Starting React render process");
 root.render(
   <React.StrictMode>
     <EnhancedErrorBoundary>
-      <Router>
-        <App />
-      </Router>
+      <ThemeProvider attribute="class" defaultTheme="light">
+        <Router>
+          <App />
+        </Router>
+      </ThemeProvider>
     </EnhancedErrorBoundary>
   </React.StrictMode>
 );

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -33,6 +33,7 @@ import NotificationSettingsForm from '@/components/NotificationSettingsForm';
 
 // ✅ NEW: Import notification triggers for demo
 import { useNotificationTriggers } from '@/hooks/useNotificationTriggers';
+import { ThemeToggle } from '@/components/ui/theme-toggle';
 
 const SettingsPage = () => {
   const { settings, saveSettings, isLoading } = useUserSettings();
@@ -170,6 +171,11 @@ const SettingsPage = () => {
               </div>
             </div>
           </div>
+        </div>
+
+        {/* Theme toggle hanya muncul di mobile */}
+        <div className="md:hidden mb-6 flex justify-end">
+          <ThemeToggle />
         </div>
 
         {/* Main Content */}


### PR DESCRIPTION
## Ringkasan
- tambah toggle tema di sidebar untuk desktop
- tampilkan toggle tema di halaman pengaturan saat mobile
- refactor `ThemeToggle` agar fleksibel dipakai di berbagai tempat
- perbaiki warna latar, teks, dan border putih agar otomatis netral di mode gelap

## Testing
- `npm test` *(gagal: Missing script: "test")*
- `npm run lint` *(gagal: 767 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a453b7c9ec832ebe433fe9936bf6db