### PR TITLE
Perbaiki layout kalkulator promo agar konsisten

### DIFF
--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -40,12 +40,12 @@ const SupplierManagementPage = React.lazy(() =>
   }))
 );
 
-const PurchaseManagement = React.lazy(() => 
+const PurchaseManagement = React.lazy(() =>
   import(/* webpackChunkName: "purchase" */ "@/components/purchase/PurchasePage")
 );
 
-const PromoCalculator = React.lazy(() => 
-  import(/* webpackChunkName: "promo" */ "@/components/promoCalculator/calculator/PromoCalculator")
+const PromoCalculatorPage = React.lazy(() =>
+  import(/* webpackChunkName: "promo" */ "@/pages/PromoCalculatorPage")
 );
 
 const PromoList = React.lazy(() => 
@@ -483,13 +483,13 @@ export const AppRouter = () => (
       />
       
       {/* ✅ Promo routes */}
-      <Route 
-        path="promo" 
+      <Route
+        path="promo"
         element={
           <RouteWrapper title="Memuat Kalkulator Promo">
-            <PromoCalculator />
+            <PromoCalculatorPage />
           </RouteWrapper>
-        } 
+        }
       />
       
       <Route 

--- a/src/pages/PromoCalculatorPage.tsx
+++ b/src/pages/PromoCalculatorPage.tsx
@@ -3,7 +3,7 @@ import PromoCalculatorIndex from '@/components/promoCalculator/index';
 
 const PromoCalculatorPage = () => {
   return (
-    <div className="w-full">
+    <div className="min-h-screen bg-gray-50">
       <PromoCalculatorIndex />
     </div>
   );


### PR DESCRIPTION
## Ringkasan
- Gunakan `PromoCalculatorPage` dengan kontainer `min-h-screen bg-gray-50` agar tampilan kalkulator promo selaras dengan halaman lain.
- Perbarui rute `/promo` untuk merender `PromoCalculatorPage` sehingga mendapatkan layout lengkap.

## Pengujian
- `npm test` *(gagal: Missing script "test")*
- `npm run lint` *(gagal: banyak kesalahan lint bawaan proyek)*
- `npx eslint src/pages/PromoCalculatorPage.tsx src/config/routes.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a460c06bcc832e8a8d8ffee92093a8