### PR TITLE
Remove dark mode toggle from sidebar and mobile settings

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -59,7 +59,6 @@ import { useProfitAnalysis } from "@/components/profitAnalysis";
 
 // --- Import Fungsi Export ---
 import { exportAllDataToExcel } from "@/utils/exportUtils";
-import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 export function AppSidebar() {
   const location = useLocation();
@@ -304,15 +303,6 @@ export function AppSidebar() {
       {/* ✅ Footer with delayed animation */}
       <SidebarFooter className="p-2 border-t mt-auto opacity-100 transition-all duration-300 delay-200 group-data-[collapsible=icon]:px-0">
         <SidebarMenu className="space-y-1">
-          {/* Theme Toggle - only for desktop */}
-          <SidebarMenuItem className="hidden md:block transition-all duration-200 ease-in-out">
-            <SidebarMenuButton asChild>
-              <ThemeToggle className="w-full">
-                <span>Tema</span>
-              </ThemeToggle>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-
           {/* Export Button */}
           <SidebarMenuItem className="transition-all duration-200 ease-in-out">
             {renderActionButton(

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -33,7 +33,6 @@ import NotificationSettingsForm from '@/components/NotificationSettingsForm';
 
 // ✅ NEW: Import notification triggers for demo
 import { useNotificationTriggers } from '@/hooks/useNotificationTriggers';
-import { ThemeToggle } from '@/components/ui/theme-toggle';
 
 const SettingsPage = () => {
   const { settings, saveSettings, isLoading } = useUserSettings();
@@ -72,7 +71,10 @@ const SettingsPage = () => {
     );
   }
 
-  const handleInputChange = (field: keyof UserSettings, value: any) => {
+  const handleInputChange = (
+    field: keyof UserSettings,
+    value: UserSettings[keyof UserSettings]
+  ) => {
     setFormState(prev => prev ? { ...prev, [field]: value } : null);
   };
 
@@ -172,12 +174,6 @@ const SettingsPage = () => {
             </div>
           </div>
         </div>
-
-        {/* Theme toggle hanya muncul di mobile */}
-        <div className="md:hidden mb-6 flex justify-end">
-          <ThemeToggle />
-        </div>
-
         {/* Main Content */}
         <div className="grid grid-cols-1 xl:grid-cols-4 gap-8">
           {/* Kolom Utama: Forms */}


### PR DESCRIPTION
## Summary
- remove ThemeToggle component from sidebar footer
- drop mobile-only ThemeToggle from settings page and tighten input handler typing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in many files, require, unused directive)*
- `npx eslint src/components/AppSidebar.tsx src/pages/Settings.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a46b89bc24832e8907f33e511bef11