### PR TITLE
feat: aktifkan tooltip klik pada grafik keuntungan

### DIFF
--- a/src/components/profitAnalysis/components/ProfitTrendChart.tsx
+++ b/src/components/profitAnalysis/components/ProfitTrendChart.tsx
@@ -262,7 +262,7 @@ const ProfitTrendChart: React.FC<ProfitTrendChartProps> = ({
           tickFormatter={(value) => viewType === 'margins' ? `${value}%` : formatLargeNumber(value)}
           axisLine={false}
         />
-        <Tooltip content={(props) => <CustomTooltip {...props} viewType={viewType} />} />
+        <Tooltip trigger="click" content={(props) => <CustomTooltip {...props} viewType={viewType} />} />
         <Legend 
           wrapperStyle={{ fontSize: '12px' }}
           iconType="circle"
@@ -305,7 +305,7 @@ const ProfitTrendChart: React.FC<ProfitTrendChartProps> = ({
           tickFormatter={(value) => formatLargeNumber(value)}
           axisLine={false}
         />
-        <Tooltip content={(props) => <CustomTooltip {...props} viewType={viewType} />} />
+        <Tooltip trigger="click" content={(props) => <CustomTooltip {...props} viewType={viewType} />} />
         <Legend 
           wrapperStyle={{ fontSize: '12px' }}
           iconType="circle"


### PR DESCRIPTION
## Ringkasan
- tambahkan properti `trigger="click"` pada Tooltip di ProfitTrendChart

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `npm run lint` (gagal: 668 errors, 97 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a478d3c53c832ea1353420e31ab749