### PR TITLE
feat: tampilkan tooltip saat tap di ProfitBreakdownChart

### DIFF
--- a/src/components/profitAnalysis/components/ProfitBreakdownChart.tsx
+++ b/src/components/profitAnalysis/components/ProfitBreakdownChart.tsx
@@ -242,7 +242,7 @@ const ProfitBreakdownChart = ({
           tickFormatter={(value) => formatLargeNumber(value)}
           axisLine={false}
         />
-        <Tooltip content={<CustomBarTooltip />} />
+        <Tooltip trigger="click" content={<CustomBarTooltip />} />
         <Legend 
           wrapperStyle={{ fontSize: '12px' }}
           iconType="circle"
@@ -305,7 +305,7 @@ const ProfitBreakdownChart = ({
             <Cell key={`cell-${index}`} fill={entry.color} />
           ))}
         </Pie>
-        <Tooltip content={<CustomPieTooltip />} />
+        <Tooltip trigger="click" content={<CustomPieTooltip />} />
       </PieChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
## Ringkasan
- mengatur Tooltip Recharts agar memicu dengan klik sehingga tooltip muncul saat pengguna mengetuk bar atau sektor pie chart

## Pengujian
- `npm run lint` (gagal: banyak `Unexpected any` di basis kode)


------
https://chatgpt.com/codex/tasks/task_e_68a478d492f4832eb6f774b6091847eb