### PR TITLE
feat: modernisasi chart profit analysis

### DIFF
--- a/src/components/promoCalculator/analytics/ProfitAnalysisChart.jsx
+++ b/src/components/promoCalculator/analytics/ProfitAnalysisChart.jsx
@@ -1,7 +1,16 @@
-// 🎯 Chart untuk analisis profit margin
+// Chart untuk analisis profit margin
 
 import React from 'react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from 'recharts';
 
 const ProfitAnalysisChart = ({ data }) => {
   const CustomTooltip = ({ active, payload, label }) => {
@@ -10,7 +19,11 @@ const ProfitAnalysisChart = ({ data }) => {
         <div className="bg-white p-3 border border-gray-200 rounded-lg shadow-lg">
           <p className="font-medium text-gray-900 mb-2">{label}</p>
           {payload.map((entry, index) => (
-            <p key={index} className="text-sm" style={{ color: entry.color }}>
+            <p key={index} className="text-sm flex items-center gap-2">
+              <span
+                className="w-2 h-2 rounded-full"
+                style={{ backgroundColor: entry.color }}
+              />
               {entry.name}: {entry.value.toFixed(1)}%
             </p>
           ))}
@@ -31,35 +44,51 @@ const ProfitAnalysisChart = ({ data }) => {
   return (
     <div className="h-64">
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-          <XAxis 
-            dataKey="date" 
+        <AreaChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+          <defs>
+            <linearGradient id="colorNormal" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="colorPromo" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#f59e0b" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="#f59e0b" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis
+            dataKey="date"
             tick={{ fontSize: 12 }}
+            axisLine={{ stroke: '#e5e7eb' }}
+            tickLine={false}
           />
-          <YAxis 
+          <YAxis
             tick={{ fontSize: 12 }}
             tickFormatter={(value) => `${value}%`}
+            axisLine={{ stroke: '#e5e7eb' }}
+            tickLine={false}
           />
           <Tooltip content={<CustomTooltip />} />
           <Legend />
-          <Line 
-            type="monotone" 
-            dataKey="normalMargin" 
-            stroke="#3b82f6" 
+          <Area
+            type="monotone"
+            dataKey="normalMargin"
+            stroke="#3b82f6"
             strokeWidth={2}
             name="Margin Normal"
-            dot={{ fill: '#3b82f6', strokeWidth: 2, r: 4 }}
+            fill="url(#colorNormal)"
+            activeDot={{ r: 6 }}
           />
-          <Line 
-            type="monotone" 
-            dataKey="promoMargin" 
-            stroke="#f59e0b" 
+          <Area
+            type="monotone"
+            dataKey="promoMargin"
+            stroke="#f59e0b"
             strokeWidth={2}
             name="Margin Promo"
-            dot={{ fill: '#f59e0b', strokeWidth: 2, r: 4 }}
+            fill="url(#colorPromo)"
+            activeDot={{ r: 6 }}
           />
-        </LineChart>
+        </AreaChart>
       </ResponsiveContainer>
     </div>
   );


### PR DESCRIPTION
## Ringkasan
- perbarui chart analisis profit dengan gaya area gradient dan tooltip lebih modern
- hapus emoticon dari menu analisis profit

## Pengujian
- `npm test` (gagal: Missing script "test")
- `npm run lint` (gagal: 777 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a4973f5828832eb7246e33a42e9a21