### PR TITLE
feat: jadikan halaman fitur utama fullwidth

### DIFF
--- a/src/components/operational-costs/OperationalCostPage.tsx
+++ b/src/components/operational-costs/OperationalCostPage.tsx
@@ -122,7 +122,7 @@ const OperationalCostContent: React.FC = () => {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <div className="bg-gradient-to-r from-orange-500 to-red-500 text-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="w-full px-4 sm:px-6 lg:px-8 py-8">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
               <div className="bg-white bg-opacity-20 p-3 rounded-xl backdrop-blur-sm">
@@ -162,7 +162,7 @@ const OperationalCostContent: React.FC = () => {
         </div>
       </div>
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+      <div className="w-full px-4 sm:px-6 lg:px-8 py-8 space-y-8">
         
         {/* Top Section: Calculator */}
         <Card>

--- a/src/components/promoCalculator/PromoCalculatorLayout.tsx
+++ b/src/components/promoCalculator/PromoCalculatorLayout.tsx
@@ -211,7 +211,7 @@ const PromoCalculatorLayout = () => {
     buttonPrimary: "bg-orange-500 hover:bg-orange-600 text-white px-6 py-2 rounded-lg font-medium transition-colors flex items-center space-x-2",
     buttonSecondary: "flex items-center space-x-2 border border-gray-300 hover:bg-gray-50 text-gray-700 px-4 py-2 rounded-lg font-medium transition-colors",
     containerLayout: "min-h-screen bg-gray-50",
-    mainContent: "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8",
+    mainContent: "w-full px-4 sm:px-6 lg:px-8 py-8",
     loadingSpinner: "animate-spin rounded-full border-t-2 border-b-2 border-orange-500",
     card: "bg-white p-6 rounded-xl border border-gray-200"
   };
@@ -492,7 +492,7 @@ const PromoCalculatorLayout = () => {
   if (currentView === 'list') {
     return (
       <div className={styles.containerLayout}>
-        <div className="max-w-7xl mx-auto">
+        <div className="w-full px-4 sm:px-6 lg:px-8">
           <ListHeader onCreateNew={() => navigate('/promo/create')} />
           <div className="bg-white rounded-t-xl border border-gray-200">
             <LazyComponent 

--- a/src/components/warehouse/WarehousePage.tsx
+++ b/src/components/warehouse/WarehousePage.tsx
@@ -424,7 +424,7 @@ const WarehousePageContent: React.FC = () => {
   // Early return for missing context
   if (!context) {
     return (
-      <div className="container mx-auto p-4 sm:p-8">
+      <div className="w-full p-4 sm:p-8">
         <div className="flex items-center justify-center h-64">
           <div className="text-center">
             <div className="text-red-500 text-4xl mb-4">⚠️</div>
@@ -446,7 +446,7 @@ const WarehousePageContent: React.FC = () => {
   const hasDialogsOpen = Object.values(core.dialogs?.states || {}).some(Boolean) || !!core.dialogs?.editingItem;
 
   return (
-    <div className="container mx-auto p-4 sm:p-8" aria-live="polite">
+    <div className="w-full p-4 sm:p-8" aria-live="polite">
       
       {/* Header Section */}
       <WarehouseHeader

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -130,7 +130,7 @@ const Dashboard = () => {
   return (
     <ErrorBoundary>
       <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
-        <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
+        <div className="w-full p-4 sm:p-6 lg:p-8">
           
           {/* 🏠 Header Section */}
           <div className="mb-8">

--- a/src/pages/MenuPage.tsx
+++ b/src/pages/MenuPage.tsx
@@ -167,7 +167,7 @@ const MenuPage = () => {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <div className="bg-white border-b sticky top-0 z-10">
-        <div className="max-w-md mx-auto px-4 py-4">
+        <div className="w-full px-4 py-4">
           <div className="flex items-center gap-3">
             <div className="w-8 h-8 bg-gradient-to-r from-orange-500 to-red-500 rounded-lg flex items-center justify-center">
               <TrendingUp className="h-4 w-4 text-white" />
@@ -181,7 +181,7 @@ const MenuPage = () => {
       </div>
 
       {/* Menu List - Simplified */}
-      <div className="max-w-md mx-auto p-4 pb-20">
+      <div className="w-full p-4 pb-20">
         <div className="space-y-3">
           {menuItems.map((item) => (
             <Card

--- a/src/pages/Recipes.tsx
+++ b/src/pages/Recipes.tsx
@@ -68,7 +68,7 @@ const CategoryManagerDialog = React.lazy(() =>
 // ✅ Better Loading Fallback
 const RecipeLoadingFallback: React.FC = () => (
   <div className="min-h-screen bg-gradient-to-br from-orange-50 to-red-50">
-    <div className="container mx-auto p-4 sm:p-6">
+    <div className="w-full p-4 sm:p-6">
       <div className="space-y-6">
         {/* Header Skeleton */}
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
@@ -359,7 +359,7 @@ const Recipes: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 to-red-50">
-      <div className="container mx-auto p-4 sm:p-6 space-y-6">
+      <div className="w-full p-4 sm:p-6 space-y-6">
         
         {/* ✅ Header - Matching Warehouse Design */}
         <div className="bg-gradient-to-r from-orange-500 to-red-500 rounded-xl p-6 mb-6 text-white border">


### PR DESCRIPTION
## Ringkasan
- hilangkan batas `max-width` di halaman Dashboard dan Resep
- perluas layout Kalkulator Promo, Gudang, dan Biaya Operasional
- lebar halaman Menu utama dibuat penuh

## Pengujian
- `npm test` (gagal karena script tidak ada)
- `npm run lint` (gagal: 679 errors, 98 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a5656be374832eb83a160a01acabe8