### PR TITLE
Tangani PGRST116 pada registrasi device

### DIFF
--- a/src/contexts/DeviceContext.tsx
+++ b/src/contexts/DeviceContext.tsx
@@ -106,9 +106,9 @@ export const DeviceProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         .select('*')
         .eq('user_id', userId)
         .eq('device_id', deviceId)
-        .single();
+        .maybeSingle();
 
-      if (fetchError && fetchError.code !== 'PGRST116') {
+      if (fetchError) {
         logger.error('Error checking existing device:', fetchError);
         return;
       }


### PR DESCRIPTION
## Ringkasan
- ganti `.single()` dengan `.maybeSingle()` saat mengecek device yang sudah terdaftar
- sederhanakan pengecekan error agar tidak memicu PGRST116 ketika baris tidak ditemukan

## Pengujian
- `npm test` (gagal: Missing script "test")
- `npm run lint` (gagal: 780 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a58d3adf70832eb63781d2cf3a47f5