### PR TITLE
feat: dukung filter harian dan tahunan

### DIFF
--- a/src/components/profitAnalysis/components/ProfitDashboard.tsx
+++ b/src/components/profitAnalysis/components/ProfitDashboard.tsx
@@ -64,7 +64,7 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
   const [activeTab, setActiveTab] = useState('ikhtisar');
   const [selectedChartType, setSelectedChartType] = useState('bar');
 
-  const [mode, setMode] = useState<'daily' | 'monthly'>('monthly');
+  const [mode, setMode] = useState<'daily' | 'monthly' | 'yearly'>('monthly');
   const [range, setRange] = useState<{ from: Date; to: Date } | undefined>(undefined);
 
   const {
@@ -92,7 +92,11 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
     currentAnalysis,
   });
 
-  const periodOptions = generatePeriodOptions(2023, new Date().getFullYear());
+  const periodOptions = generatePeriodOptions(
+    2023,
+    new Date().getFullYear(),
+    mode === 'yearly' ? 'yearly' : 'monthly'
+  );
 
   const advancedMetrics = showAdvancedMetrics
     ? calculateAdvancedMetricsHelper(profitHistory, currentAnalysis)
@@ -114,9 +118,7 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
   const hasValidData = Boolean(currentAnalysis?.revenue_data?.total);
 
   const handlePeriodChange = (period: string) => {
-    // Ensure monthly mode when picking a period
-    setMode('monthly');
-    // Clear any daily range
+    // Clear any daily range when picking period
     setRange(undefined);
     setCurrentPeriod(period);
   };
@@ -133,16 +135,16 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
     }
   };
 
-  // Wire mode toggle: when switching to daily, set default date range (this month to today)
-  const handleModeChange = (m: 'daily' | 'monthly') => {
+  // Wire mode toggle: atur rentang/period sesuai mode
+  const handleModeChange = (m: 'daily' | 'monthly' | 'yearly') => {
     setMode(m);
     if (m === 'daily') {
       const now = new Date();
       const firstOfThisMonth = new Date(now.getFullYear(), now.getMonth(), 1);
       setRange({ from: firstOfThisMonth, to: now });
     } else {
-      // monthly mode: clear range so API uses period string
       setRange(undefined);
+      setCurrentPeriod(getCurrentPeriod(m === 'yearly' ? 'yearly' : 'monthly'));
     }
   };
 

--- a/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
+++ b/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
@@ -46,9 +46,9 @@ export interface DashboardHeaderSectionProps {
   statusIndicators?: StatusIndicator[];
   onPeriodChange: (period: string) => void;
   onRefresh: () => void;
-  // 🆕 Daily/Monthly mode + date range presets
-  mode?: 'daily' | 'monthly';
-  onModeChange?: (mode: 'daily' | 'monthly') => void;
+  // 🆕 Mode harian/bulanan/tahunan + preset rentang tanggal
+  mode?: 'daily' | 'monthly' | 'yearly';
+  onModeChange?: (mode: 'daily' | 'monthly' | 'yearly') => void;
   dateRange?: { from: Date; to: Date };
   onDateRangeChange?: (range: { from: Date; to: Date }) => void;
 }
@@ -93,6 +93,14 @@ const DashboardHeaderSection: React.FC<DashboardHeaderSectionProps> = ({
         >
           Bulanan
         </button>
+        <button
+          className={`px-3 py-1 text-sm ${
+            mode === 'yearly' ? 'bg-white text-orange-600' : 'text-white opacity-75'
+          }`}
+          onClick={() => onModeChange?.('yearly')}
+        >
+          Tahunan
+        </button>
       </div>
 
       {/* Period or Date Range */}
@@ -109,7 +117,7 @@ const DashboardHeaderSection: React.FC<DashboardHeaderSectionProps> = ({
             ))}
           </SelectContent>
         </Select>
-      ) : (
+      ) : mode === 'daily' ? (
         <div className="flex items-center gap-2">
           <Select
             onValueChange={(val) => {
@@ -144,6 +152,19 @@ const DashboardHeaderSection: React.FC<DashboardHeaderSectionProps> = ({
             )}
           </div>
         </div>
+      ) : (
+        <Select value={currentPeriod} onValueChange={onPeriodChange}>
+          <SelectTrigger className="w-full md:w-40 bg-white text-orange-600 border-none focus:ring-0">
+            <SelectValue placeholder="Pilih tahun" />
+          </SelectTrigger>
+          <SelectContent>
+            {periodOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       )}
 
       {/* Action Buttons */}

--- a/src/components/profitAnalysis/hooks/useProfitAnalysis.ts
+++ b/src/components/profitAnalysis/hooks/useProfitAnalysis.ts
@@ -39,8 +39,8 @@ export interface UseProfitAnalysisOptions {
   enableRealTime?: boolean;
   // ✅ ADD WAC OPTIONS
   enableWAC?: boolean;
-  // 🆕 Mode harian/bulanan dan rentang tanggal
-  mode?: 'daily' | 'monthly';
+  // 🆕 Mode harian/bulanan/tahunan dan rentang tanggal
+  mode?: 'daily' | 'monthly' | 'yearly';
   dateRange?: { from: Date; to: Date };
 }
 
@@ -108,11 +108,12 @@ export const useProfitAnalysis = (
   const [profitHistory, setProfitHistory] = useState<RealTimeProfitCalculation[]>([]);
   const [error, setError] = useState<string | null>(null);
 
-  // ✅ MAIN QUERY: Current analysis (supports monthly or daily)
+  // ✅ MAIN QUERY: Current analysis (supports harian, bulanan, tahunan)
   const currentAnalysisQuery = useQuery({
-    queryKey: mode === 'daily'
-      ? ['profit-analysis','daily', dateRange?.from?.toISOString(), dateRange?.to?.toISOString()]
-      : PROFIT_QUERY_KEYS.realTime(currentPeriod),
+    queryKey:
+      mode === 'daily'
+        ? ['profit-analysis', 'daily', dateRange?.from?.toISOString(), dateRange?.to?.toISOString()]
+        : ['profit-analysis', 'realtime', mode, currentPeriod],
     queryFn: async () => {
       try {
         if (mode === 'daily') {
@@ -126,6 +127,16 @@ export const useProfitAnalysis = (
           setProfitHistory(daily.data || []);
           return last;
         }
+
+        if (mode === 'yearly') {
+          logger.info('🔄 Fetching yearly profit analysis:', { period: currentPeriod });
+          const response = await profitAnalysisApi.calculateProfitAnalysis(currentPeriod, 'yearly');
+          if (response.error) {
+            throw new Error(response.error);
+          }
+          return response.data;
+        }
+
         logger.info('🔄 Fetching profit analysis for period:', currentPeriod);
         const response = await profitAnalysisApi.calculateProfitAnalysis(currentPeriod);
         if (response.error) {
@@ -134,7 +145,7 @@ export const useProfitAnalysis = (
         logger.success('✅ Profit analysis completed:', {
           period: currentPeriod,
           revenue: response.data?.revenue_data?.total || 0,
-          calculatedAt: response.data?.calculated_at
+          calculatedAt: response.data?.calculated_at,
         });
         return response.data;
       } catch (err) {
@@ -319,26 +330,41 @@ export const useProfitAnalysis = (
   }, [revenue, cogs, opex, currentData, totalHPP, hppBreakdown]); // ✅ Sekarang menggunakan primitive value dan data WAC
 
   // ✅ ACTIONS
-  const calculateProfit = useCallback(async (period?: string): Promise<boolean> => {
-    const targetPeriod = period || currentPeriod;
-    
-    try {
-      setError(null);
-      if (mode === 'daily') {
-        const from = dateRange?.from ?? new Date(new Date().getFullYear(), new Date().getMonth(), 1);
-        const to = dateRange?.to ?? new Date();
-        const res = await calculateProfitAnalysisDaily(from, to);
-        if (!res.success) throw new Error(res.error || 'Failed daily calculate');
-        setProfitHistory(res.data || []);
+  const calculateProfit = useCallback(
+    async (period?: string): Promise<boolean> => {
+      const targetPeriod = period || currentPeriod;
+
+      try {
+        setError(null);
+        if (mode === 'daily') {
+          const from =
+            dateRange?.from ?? new Date(new Date().getFullYear(), new Date().getMonth(), 1);
+          const to = dateRange?.to ?? new Date();
+          const res = await calculateProfitAnalysisDaily(from, to);
+          if (!res.success) throw new Error(res.error || 'Failed daily calculate');
+          setProfitHistory(res.data || []);
+          return true;
+        }
+
+        if (mode === 'yearly') {
+          const res = await profitAnalysisApi.calculateProfitAnalysis(targetPeriod, 'yearly');
+          if (res.error) throw new Error(res.error);
+          queryClient.setQueryData(
+            ['profit-analysis', 'realtime', 'yearly', targetPeriod],
+            res.data
+          );
+          return true;
+        }
+
+        await calculateProfitMutation.mutateAsync(targetPeriod);
         return true;
+      } catch (error) {
+        logger.error('❌ Calculate profit failed:', error);
+        return false;
       }
-      await calculateProfitMutation.mutateAsync(targetPeriod);
-      return true;
-    } catch (error) {
-      logger.error('❌ Calculate profit failed:', error);
-      return false;
-    }
-  }, [currentPeriod, calculateProfitMutation]);
+    },
+    [currentPeriod, calculateProfitMutation, mode, dateRange, queryClient]
+  );
 
   const loadProfitHistory = useCallback(async (dateRange?: DateRangeFilter) => {
     try {

--- a/src/components/profitAnalysis/hooks/useProfitData.ts
+++ b/src/components/profitAnalysis/hooks/useProfitData.ts
@@ -57,18 +57,23 @@ export const useProfitData = (
   const formatPeriodLabel = useCallback((period: string): string => {
     try {
       if (!period || typeof period !== 'string') return period || '';
-      
+
+      // Jika hanya tahun, format sebagai "Tahun XXXX"
+      if (/^\d{4}$/.test(period)) {
+        return `Tahun ${period}`;
+      }
+
       const [year, month] = period.split('-');
       if (!year || !month) return period;
-      
+
       const monthNames = [
         'Januari', 'Februari', 'Maret', 'April', 'Mei', 'Juni',
         'Juli', 'Agustus', 'September', 'Oktober', 'November', 'Desember'
       ];
-      
+
       const monthIndex = parseInt(month) - 1;
       if (monthIndex < 0 || monthIndex >= monthNames.length) return period;
-      
+
       return `${monthNames[monthIndex]} ${year}`;
     } catch (error) {
       console.error('Error formatting period label:', error);

--- a/src/components/profitAnalysis/utils/profitTransformers.ts
+++ b/src/components/profitAnalysis/utils/profitTransformers.ts
@@ -514,25 +514,33 @@ export const getGrowthStatus = (growthPercentage: number) => {
  */
 export const generatePeriodOptions = (
   startYear: number = 2023,
-  endYear: number = new Date().getFullYear()
+  endYear: number = new Date().getFullYear(),
+  type: 'monthly' | 'yearly' = 'monthly'
 ) => {
-  const options = [];
-  
+  const options = [] as Array<{ value: string; label: string }>;
+
   for (let year = endYear; year >= startYear; year--) {
+    if (type === 'yearly') {
+      const period = `${year}`;
+      const label = formatPeriodLabel(period, 'yearly');
+      options.push({ value: period, label });
+      continue;
+    }
+
     for (let month = 12; month >= 1; month--) {
       // Stop at current month for current year
       if (year === endYear && month > new Date().getMonth() + 1) {
         continue;
       }
-      
+
       const monthStr = month.toString().padStart(2, '0');
       const period = `${year}-${monthStr}`;
       const label = formatPeriodLabel(period);
-      
+
       options.push({ value: period, label });
     }
   }
-  
+
   return options;
 };
 


### PR DESCRIPTION
## Ringkasan
- tambah opsi mode harian/bulanan/tahunan pada dashboard analisis profit
- preset rentang tanggal harian (bulan ini, bulan kemarin, 30 hari terakhir)
- dukungan pemilihan tahun untuk laporan tahunan

## Pengujian
- `npm test` (gagal: Missing script "test")
- `npm run lint` (gagal: banyak error eslint yang sudah ada)


------
https://chatgpt.com/codex/tasks/task_e_68a593ae71f8832eb0c57de1aa0c729d