### PR TITLE
fix: persist financial categories in user settings

### DIFF
--- a/src/contexts/UserSettingsContext.tsx
+++ b/src/contexts/UserSettingsContext.tsx
@@ -5,6 +5,10 @@ import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './AuthContext';
 import { logger } from '@/utils/logger';
+import {
+  DEFAULT_FINANCIAL_CATEGORIES,
+  FinancialCategories,
+} from '@/components/financial/types/financial';
 
 // ===== TYPES =====
 export interface UserSettings {
@@ -17,6 +21,7 @@ export interface UserSettings {
     lowStock: boolean;
     newOrder: boolean;
   };
+  financialCategories: FinancialCategories;
   updatedAt?: string;
 }
 
@@ -45,6 +50,7 @@ const defaultSettings: UserSettings = {
     lowStock: true,
     newOrder: true,
   },
+  financialCategories: DEFAULT_FINANCIAL_CATEGORIES,
 };
 
 // ===== API FUNCTIONS =====
@@ -91,6 +97,7 @@ const userSettingsApi = {
         lowStock: data.notifications?.lowStock ?? defaultSettings.notifications.lowStock,
         newOrder: data.notifications?.newOrder ?? defaultSettings.notifications.newOrder,
       },
+      financialCategories: data.financial_categories || data.financialCategories || defaultSettings.financialCategories,
       updatedAt: data.updated_at || data.updatedAt || new Date().toISOString()
     };
 
@@ -109,6 +116,7 @@ const userSettingsApi = {
       phone: settings.phone,
       address: settings.address,
       notifications: settings.notifications,
+      financial_categories: settings.financialCategories,
       updated_at: new Date().toISOString()
     };
 
@@ -140,6 +148,7 @@ const userSettingsApi = {
       phone: data.phone || '',
       address: data.address || '',
       notifications: data.notifications || defaultSettings.notifications,
+      financialCategories: data.financial_categories || defaultSettings.financialCategories,
       updatedAt: data.updated_at
     };
 


### PR DESCRIPTION
## Summary
- add financialCategories to user settings
- persist financialCategories when loading and saving settings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5941f5048832e9d9d964517003ff2