### PR TITLE
Perbaiki stok ganda saat status pembelian diselesaikan

### DIFF
--- a/src/components/purchase/context/PurchaseContext.tsx
+++ b/src/components/purchase/context/PurchaseContext.tsx
@@ -136,7 +136,8 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             id: newId,
             nama: item.nama,
             kategori: 'Lainnya',
-            stok: item.kuantitas,
+            // Stok awal 0; penambahan stok dilakukan saat status purchase menjadi 'completed'
+            stok: 0,
             minimum: 0,
             satuan: item.satuan || '-',
             harga: item.hargaSatuan || 0,
@@ -232,7 +233,8 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
               id: item.bahanBakuId,
               nama: item.nama,
               kategori: 'Lainnya',
-              stok: item.kuantitas,
+              // Jika purchase belum selesai, stok awal tetap 0 agar tidak double saat diselesaikan
+              stok: newRow.status === 'completed' ? item.kuantitas : 0,
               minimum: 0,
               satuan: item.satuan || '-',
               harga: item.hargaSatuan || 0,


### PR DESCRIPTION
## Ringkasan
- Atur stok awal bahan baku baru menjadi 0 agar tidak langsung masuk ke gudang
- Saat membuat pembelian baru, stok bahan baku ditambah hanya jika statusnya sudah `completed`

## Pengujian
- `bun test` (gagal: 4 gagal)
- `npm run lint` (gagal: 679 errors, 100 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a595d6c4f4832ea100381872e89521