### PR TITLE
Gunakan rentang tanggal kustom di analisis profit

### DIFF
--- a/src/components/profitAnalysis/components/ProfitDashboard.tsx
+++ b/src/components/profitAnalysis/components/ProfitDashboard.tsx
@@ -148,7 +148,7 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
     }
   };
 
-  // Wire date range changes: ensure we are in daily mode when user picks a preset
+  // Sinkronkan perubahan rentang tanggal: paksa mode harian saat pengguna memilih rentang
   const handleDateRangeChange = (r: { from: Date; to: Date }) => {
     if (mode !== 'daily') setMode('daily');
     setRange(r);

--- a/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
+++ b/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import DateRangePicker from '@/components/ui/DateRangePicker';
 import {
   RotateCw,
   CheckCircle,
@@ -46,7 +47,7 @@ export interface DashboardHeaderSectionProps {
   statusIndicators?: StatusIndicator[];
   onPeriodChange: (period: string) => void;
   onRefresh: () => void;
-  // 🆕 Mode harian/bulanan/tahunan + preset rentang tanggal
+  // 🆕 Mode harian/bulanan/tahunan + rentang tanggal kustom
   mode?: 'daily' | 'monthly' | 'yearly';
   onModeChange?: (mode: 'daily' | 'monthly' | 'yearly') => void;
   dateRange?: { from: Date; to: Date };
@@ -118,40 +119,11 @@ const DashboardHeaderSection: React.FC<DashboardHeaderSectionProps> = ({
           </SelectContent>
         </Select>
       ) : mode === 'daily' ? (
-        <div className="flex items-center gap-2">
-          <Select
-            onValueChange={(val) => {
-              const now = new Date();
-              const firstOfThisMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-              const lastOfPrevMonth = new Date(now.getFullYear(), now.getMonth(), 0);
-              const firstOfPrevMonth = new Date(lastOfPrevMonth.getFullYear(), lastOfPrevMonth.getMonth(), 1);
-              const last30 = new Date();
-              last30.setDate(now.getDate() - 29);
-              if (val === 'this_month') onDateRangeChange?.({ from: firstOfThisMonth, to: now });
-              if (val === 'last_month') onDateRangeChange?.({ from: firstOfPrevMonth, to: lastOfPrevMonth });
-              if (val === 'last_30') onDateRangeChange?.({ from: last30, to: now });
-            }}
-          >
-            <SelectTrigger className="w-full md:w-40 bg-white text-orange-600 border-none focus:ring-0">
-              <SelectValue placeholder="Preset" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="this_month">Bulan ini</SelectItem>
-              <SelectItem value="last_month">Bulan kemarin</SelectItem>
-              <SelectItem value="last_30">30 hari terakhir</SelectItem>
-            </SelectContent>
-          </Select>
-          <div className="text-xs text-white">
-            {dateRange ? (
-              <span>
-                {dateRange.from.toLocaleDateString('id-ID')} —
-                {dateRange.to.toLocaleDateString('id-ID')}
-              </span>
-            ) : (
-              <span>Pilih rentang</span>
-            )}
-          </div>
-        </div>
+        <DateRangePicker
+          dateRange={dateRange}
+          onDateRangeChange={onDateRangeChange}
+          className="w-full md:w-64 bg-white text-orange-600 border-none focus:ring-0"
+        />
       ) : (
         <Select value={currentPeriod} onValueChange={onPeriodChange}>
           <SelectTrigger className="w-full md:w-40 bg-white text-orange-600 border-none focus:ring-0">

--- a/src/components/profitAnalysis/hooks/useProfitAnalysis.ts
+++ b/src/components/profitAnalysis/hooks/useProfitAnalysis.ts
@@ -168,15 +168,27 @@ export const useProfitAnalysis = (
   });
 
   const pemakaianQuery = useQuery({
-    queryKey: PROFIT_QUERY_KEYS.pemakaian(currentPeriod, currentPeriod),
+    queryKey:
+      mode === 'daily' && dateRange
+        ? PROFIT_QUERY_KEYS.pemakaian(
+            dateRange.from.toISOString(),
+            dateRange.to.toISOString()
+          )
+        : PROFIT_QUERY_KEYS.pemakaian(currentPeriod, currentPeriod),
     queryFn: async () => {
-      const start = currentPeriod + '-01';
-      const end = new Date(new Date(currentPeriod + '-01').getFullYear(), 
-                          new Date(currentPeriod + '-01').getMonth() + 1, 0)
-                  .toISOString().split('T')[0];
+      if (mode === 'daily' && dateRange) {
+        const start = dateRange.from.toISOString().split('T')[0];
+        const end = dateRange.to.toISOString().split('T')[0];
+        return fetchPemakaianByPeriode(start, end);
+      }
+      const startDate = new Date(currentPeriod + '-01');
+      const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + 1, 0);
+      const start = startDate.toISOString().split('T')[0];
+      const end = endDate.toISOString().split('T')[0];
       return fetchPemakaianByPeriode(start, end);
     },
-    enabled: enableWAC && Boolean(currentPeriod),
+    enabled:
+      enableWAC && (mode === 'daily' ? Boolean(dateRange) : Boolean(currentPeriod)),
     staleTime: 60 * 1000, // 1 minute
   });
 


### PR DESCRIPTION
## Ringkasan
- Normalisasi string tanggal sebelum memanggil Supabase agar selalu berformat YYYY-MM-DD
- Sesuaikan query data WAC supaya mengikuti rentang tanggal saat mode harian

## Pengujian
- `npm test` *(gagal: Missing script "test")*
- `npm run lint` *(gagal: 779 problems (679 errors, 100 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a5a91017e8832e926dfca7efd9f233