### PR TITLE
Perbaikan tag dashboard header dan dukungan pergantian mode

### DIFF
--- a/src/components/profitAnalysis/components/ProfitDashboard.tsx
+++ b/src/components/profitAnalysis/components/ProfitDashboard.tsx
@@ -5,8 +5,8 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertTriangle } from 'lucide-react';
 
 // Import hooks dan utilities
-import { useProfitAnalysis } from '../hooks';
-import { getCurrentPeriod } from '../utils/profitTransformers';
+import { useProfitAnalysis, useProfitData } from '../hooks';
+import { getCurrentPeriod, generatePeriodOptions } from '../utils/profitTransformers';
 import { calculateMargins } from '../utils/profitCalculations';
 
 // Import dashboard sections and tabs
@@ -69,6 +69,7 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
     loading,
     error,
     currentPeriod,
+    setCurrentPeriod,
     refreshAnalysis,
     profitMetrics,
     labels,
@@ -155,11 +156,11 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
   const safeOpex = currentAnalysis?.opex_data?.total ?? 0;
   const footerCalc = calculateMargins(safeRevenue, safeCogs, safeOpex);
 
-  return (
-    <div className={`p-4 sm:p-6 lg:p-8 space-y-6 ${className}`}>
-      <DashboardHeaderSection
-        hasValidData={hasValidData}
-        isLoading={loading}
+    return (
+      <div className={`p-4 sm:p-6 lg:p-8 space-y-6 ${className}`}>
+        <DashboardHeaderSection
+          hasValidData={hasValidData}
+          isLoading={loading}
         quickStatus={{
           netProfit: footerCalc.netProfit,
           cogsPercentage: (safeCogs / Math.max(safeRevenue, 1)) * 100,
@@ -170,10 +171,15 @@ const ProfitDashboard: React.FC<ProfitDashboardProps> = ({
           ...(lastCalculated ? [{ type: 'updated' as const, label: 'Diperbarui', timestamp: lastCalculated }] : []),
           ...(benchmark?.competitive?.position ? [{ type: 'benchmark' as const, label: benchmark.competitive.position, position: benchmark.competitive.position }] : [])
         ]}
-        onRefresh={handleRefresh}
-        dateRange={range}
-        onDateRangeChange={handleDateRangeChange}
-      />
+          onRefresh={handleRefresh}
+          dateRange={range}
+          onDateRangeChange={handleDateRangeChange}
+          mode={mode}
+          onModeChange={handleModeChange}
+          currentPeriod={currentPeriod}
+          onPeriodChange={handlePeriodChange}
+          periodOptions={periodOptions}
+        />
       
       {error && (
         <Alert variant="destructive">

--- a/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
+++ b/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
@@ -35,6 +35,9 @@ export interface DashboardHeaderSectionProps {
   // 🆕 Mode harian/bulanan/tahunan + preset rentang tanggal
   mode?: 'daily' | 'monthly' | 'yearly';
   onModeChange?: (mode: 'daily' | 'monthly' | 'yearly') => void;
+  currentPeriod?: string;
+  onPeriodChange?: (period: string) => void;
+  periodOptions?: { value: string; label: string }[];
 
   dateRange?: { from: Date; to: Date };
   onDateRangeChange?: (range: { from: Date; to: Date }) => void;
@@ -53,23 +56,21 @@ const DashboardHeaderSection: React.FC<DashboardHeaderSectionProps> = ({
   statusIndicators = [],
   onRefresh,
   dateRange,
-  onDateRangeChange
+  onDateRangeChange,
+  mode = 'monthly',
+  onModeChange,
+  currentPeriod,
+  onPeriodChange,
+  periodOptions = [],
 }) => {
   const Controls = () => (
     <>
       <div className="flex items-center gap-2">
-        <Select
-          onValueChange={(val) => {
-            const now = new Date();
-            const firstOfThisMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-            const lastOfPrevMonth = new Date(now.getFullYear(), now.getMonth(), 0);
-            const firstOfPrevMonth = new Date(lastOfPrevMonth.getFullYear(), lastOfPrevMonth.getMonth(), 1);
-            const last30 = new Date();
-            last30.setDate(now.getDate() - 29);
-            if (val === 'this_month') onDateRangeChange?.({ from: firstOfThisMonth, to: now });
-            if (val === 'last_month') onDateRangeChange?.({ from: firstOfPrevMonth, to: lastOfPrevMonth });
-            if (val === 'last_30') onDateRangeChange?.({ from: last30, to: now });
-          }}
+        <button
+          className={`px-3 py-1 text-sm ${
+            mode === 'daily' ? 'bg-white text-orange-600' : 'text-white opacity-75'
+          }`}
+          onClick={() => onModeChange?.('daily')}
         >
           Harian
         </button>


### PR DESCRIPTION
## Ringkasan
- perbaiki tag `Select` yang salah ditutup dan ganti menjadi tombol `Harian`
- tambahkan properti mode dan periode pada `DashboardHeaderSection`
- kirim mode dan opsi periode dari `ProfitDashboard`

## Pengujian
- `pnpm lint` *(gagal: Unexpected any & require import)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a5b7c0e94c832e9ea4f3da42bce2b5