### PR TITLE
Perbaiki penggunaan refreshSettings pada CategoryManagementDialog

### DIFF
--- a/src/components/financial/dialogs/CategoryManagementDialog.tsx
+++ b/src/components/financial/dialogs/CategoryManagementDialog.tsx
@@ -161,7 +161,8 @@ const CategoryManagementDialog: React.FC<CategoryManagementDialogProps> = ({
   isOpen,
   onClose,
   settings,
-  saveSettings
+  saveSettings,
+  refreshSettings
 }) => {
   const [newIncomeCategory, setNewIncomeCategory] = useState('');
   const [newExpenseCategory, setNewExpenseCategory] = useState('');
@@ -231,7 +232,7 @@ const CategoryManagementDialog: React.FC<CategoryManagementDialogProps> = ({
         }
       }
     },
-    [settings, saveSettings]
+    [settings, saveSettings, refreshSettings]
   );
 
   const deleteCategory = useCallback(
@@ -256,7 +257,7 @@ const CategoryManagementDialog: React.FC<CategoryManagementDialogProps> = ({
         }
       }
     },
-    [settings, saveSettings]
+    [settings, saveSettings, refreshSettings]
   );
 
   const handleAddIncomeCategory = useCallback(() => {


### PR DESCRIPTION
## Ringkasan
- tambahkan prop `refreshSettings` pada `CategoryManagementDialog`
- sertakan `refreshSettings` dalam dependency `useCallback`

## Pengujian
- `npm test` *(gagal: Missing script: "test")*
- `npm run lint` *(gagal: 779 problems (678 errors, 101 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a5b9545630832e8ad9e83cf13ed1e5