### PR TITLE
Perbaiki penggunaan refreshSettings dan penutupan tag Select

### DIFF
--- a/src/components/financial/dialogs/CategoryManagementDialog.tsx
+++ b/src/components/financial/dialogs/CategoryManagementDialog.tsx
@@ -161,7 +161,8 @@ const CategoryManagementDialog: React.FC<CategoryManagementDialogProps> = ({
   isOpen,
   onClose,
   settings,
-  saveSettings
+  saveSettings,
+  refreshSettings
 }) => {
   const [newIncomeCategory, setNewIncomeCategory] = useState('');
   const [newExpenseCategory, setNewExpenseCategory] = useState('');
@@ -231,7 +232,7 @@ const CategoryManagementDialog: React.FC<CategoryManagementDialogProps> = ({
         }
       }
     },
-    [settings, saveSettings]
+    [settings, saveSettings, refreshSettings]
   );
 
   const deleteCategory = useCallback(
@@ -256,7 +257,7 @@ const CategoryManagementDialog: React.FC<CategoryManagementDialogProps> = ({
         }
       }
     },
-    [settings, saveSettings]
+    [settings, saveSettings, refreshSettings]
   );
 
   const handleAddIncomeCategory = useCallback(() => {

--- a/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
+++ b/src/components/profitAnalysis/components/sections/DashboardHeaderSection.tsx
@@ -72,7 +72,7 @@ const DashboardHeaderSection: React.FC<DashboardHeaderSectionProps> = ({
           }}
         >
           Harian
-        </button>
+        </Select>
         <button
           className={`px-3 py-1 text-sm ${
             mode === 'monthly' ? 'bg-white text-orange-600' : 'text-white opacity-75'


### PR DESCRIPTION
## Ringkasan
- tambahkan prop `refreshSettings` dan panggil setelah penyimpanan kategori pada `CategoryManagementDialog`
- sertakan `refreshSettings` pada dependency `useCallback`
- perbaiki tag penutup `Select` pada `DashboardHeaderSection`

## Pengujian
- `npm test` *(gagal: Missing script: "test")*
- `npm run lint` *(gagal: 778 problems (677 errors, 101 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a5b9545630832e8ad9e83cf13ed1e5