### PR TITLE
feat: tampilkan peringatan stok hampir habis

### DIFF
--- a/src/components/warehouse/WarehousePage.tsx
+++ b/src/components/warehouse/WarehousePage.tsx
@@ -32,6 +32,7 @@ const warehouseQueryKeys = {
 // ✅ TAMBAH: Import existing warehouse service
 import { warehouseApi } from './services/warehouseApi';
 import { supabase } from '@/integrations/supabase/client';
+import { warehouseUtils } from './services/warehouseUtils';
 
 // ✅ TAMBAH: API functions menggunakan existing service
 let crudService: any = null;
@@ -340,10 +341,11 @@ const WarehousePageContent: React.FC = () => {
   const pageId = useRef(`warehouse-${Date.now()}`);
   const isMountedRef = useRef(true);
   const navigate = useNavigate();
-  
+
   // ✅ TAMBAH: Use warehouse data hook
   const warehouseData = useWarehouseData();
-  
+  const lowStockCountRef = useRef(0);
+
   // ✅ FIXED: Create context-like object with all required CRUD functions
   const context = {
     bahanBaku: warehouseData.bahanBaku,
@@ -374,6 +376,16 @@ const WarehousePageContent: React.FC = () => {
   };
   
   const core = useWarehouseCore(context);
+
+  useEffect(() => {
+    if (warehouseData.bahanBaku) {
+      const lowStockCount = warehouseUtils.getLowStockItems(warehouseData.bahanBaku).length;
+      if (lowStockCount > 0 && lowStockCount !== lowStockCountRef.current) {
+        toast.warning(`${lowStockCount} item stok hampir habis`);
+      }
+      lowStockCountRef.current = lowStockCount;
+    }
+  }, [warehouseData.bahanBaku]);
 
   // OPTIMIZED: Simplified effect
   useEffect(() => {

--- a/src/components/warehouse/components/WarehouseHeader.tsx
+++ b/src/components/warehouse/components/WarehouseHeader.tsx
@@ -152,7 +152,7 @@ const WarehouseHeader: React.FC<WarehouseHeaderProps> = ({
             <div className="flex-1">
               <span className="text-sm font-medium">Perhatian: </span>
               <span className="text-sm">
-                {stats.lowStockCount > 0 && `${stats.lowStockCount} item stok rendah`}
+                {stats.lowStockCount > 0 && `${stats.lowStockCount} item stok hampir habis`}
                 {stats.lowStockCount > 0 && stats.expiringCount > 0 && ', '}
                 {stats.expiringCount > 0 && `${stats.expiringCount} item akan kadaluarsa`}
               </span>

--- a/src/components/warehouse/components/WarehouseTable.tsx
+++ b/src/components/warehouse/components/WarehouseTable.tsx
@@ -9,11 +9,13 @@ import {
   ArrowUp,
   ArrowDown,
   RefreshCw,
+  AlertTriangle,
 } from 'lucide-react';
 import type { BahanBakuFrontend, SortConfig } from '../types';
 import { logger } from '@/utils/logger';
 import WarehouseTableRow from './WarehouseTableRow';
 import { useWarehouseSelection } from '../hooks/useWarehouseSelection';
+import { warehouseUtils } from '../services/warehouseUtils';
 
 interface WarehouseTableProps {
   items: BahanBakuFrontend[];
@@ -52,6 +54,8 @@ const WarehouseTable: React.FC<WarehouseTableProps> = ({
     isRefreshing,
     handleRefresh,
   } = useWarehouseSelection(items, isSelectionMode, onRefresh);
+
+  const lowStockItems = warehouseUtils.getLowStockItems(items);
 
   useEffect(() => {
     if (import.meta.env.DEV && items.length > 0) {
@@ -304,6 +308,12 @@ const WarehouseTable: React.FC<WarehouseTableProps> = ({
 
   return (
     <div className="bg-white rounded-lg border border-gray-200">
+      {lowStockItems.length > 0 && (
+        <div className="p-3 bg-red-50 border-b border-red-200 text-red-800 text-sm flex items-center gap-2">
+          <AlertTriangle className="w-4 h-4" />
+          {lowStockItems.length} item stok hampir habis
+        </div>
+      )}
       <MobileCardView />
       <DesktopTableView />
     </div>


### PR DESCRIPTION
## Ringkasan
- tampilkan banner peringatan di tabel gudang saat ada item stok rendah
- ubah header gudang agar menyorot item dengan stok hampir habis
- tambahkan toast otomatis ketika jumlah stok rendah terdeteksi

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `node --test src/components/warehouse/__tests__/warehouseCalculations.test.ts` (gagal: Cannot find module '.../warehouseUtils')
- `npm run lint` (gagal: 677 errors, 101 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a5ce2b35c0832eaaa927f39182297a