### PR TITLE
Tambahkan dukungan WAC pada warehouseApi

### DIFF
--- a/src/components/warehouse/services/warehouseApi.ts
+++ b/src/components/warehouse/services/warehouseApi.ts
@@ -47,6 +47,7 @@ const transformToDatabase = (frontendItem: Partial<BahanBakuFrontend>, userId?: 
     minimum: frontendItem.minimum,
     satuan: frontendItem.satuan,
     harga_satuan: frontendItem.harga,
+    harga_rata_rata: frontendItem.hargaRataRata,
     supplier: frontendItem.supplier,
     tanggal_kadaluwarsa: frontendItem.expiry || null,
   };


### PR DESCRIPTION
## Ringkasan
- sertakan `harga_rata_rata` saat mengubah data dari frontend ke database
- memungkinkan `updateBahanBaku` mengirim nilai WAC

## Pengujian
- `pnpm lint` (gagal: Unexpected any & require import)


------
https://chatgpt.com/codex/tasks/task_e_68a5dba977a8832e926c49f6a77a8af8