### PR TITLE
Sinkronisasi purchase ke gudang untuk WAC & stok

### DIFF
--- a/src/components/warehouse/services/warehouseSyncService.ts
+++ b/src/components/warehouse/services/warehouseSyncService.ts
@@ -288,7 +288,7 @@ export class WarehouseSyncService {
           const percentDiff = priceDiff / item.harga_satuan;
           
           if (percentDiff > 1.0) { // > 100% difference
-            itemIssues.push(`Harga rata-rata sangat berbeda dari harga satuan (${percentDiff * 100:.1f}%)`);
+            itemIssues.push(`Harga rata-rata sangat berbeda dari harga satuan (${(percentDiff * 100).toFixed(1)}%)`);
             suggestions.push('Periksa data pembelian atau update harga satuan');
             severity = 'medium';
           }


### PR DESCRIPTION
## Ringkasan
- terapkan pembelian langsung ke gudang saat status selesai
- rollback stok gudang ketika status pembelian berubah dari selesai
- impor utilitas sinkronisasi gudang untuk pembaruan stok dan WAC
- perbaiki format persentase WAC agar layanan sinkronisasi dapat dibangun

## Pengujian
- `npm test` *(gagal: Missing script: "test")*
- `npm run lint` *(gagal: 802 problems (700 errors, 102 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a5e0a08990832eb85f8dbbc6ebb2f9