### PR TITLE
Sinkronkan status pembelian dengan stok dan WAC

### DIFF
--- a/src/components/purchase/__tests__/purchaseWarehouseSync.test.ts
+++ b/src/components/purchase/__tests__/purchaseWarehouseSync.test.ts
@@ -15,8 +15,7 @@ const db = {
           bahanBakuId: 'item1',
           kuantitas: 100,
           hargaSatuan: 2000,
-          subtotal: 200000,
-          prev: { stok: 0, wac: 0 }
+          subtotal: 200000
         }
       ]
     }
@@ -26,46 +25,65 @@ const db = {
   }
 };
 
-function applyUpdate(table: string, payload: any, filters: Record<string, any>) {
-  if (table !== 'purchases') return;
-  const id = filters.id;
-  const purchase = (db.purchases as any)[id];
-  if (!purchase) return;
-
-  if (payload.status === 'completed' && purchase.status !== 'completed') {
-    purchase.status = 'completed';
-    purchase.items.forEach((item: any) => {
-      const wh = (db.warehouse as any)[item.bahanBakuId];
-      item.prev = { stok: wh.stok, wac: wh.hargaRataRata };
-      const newStock = wh.stok + item.kuantitas;
-      const newWac = ((wh.stok * wh.hargaRataRata) + (item.kuantitas * item.hargaSatuan)) / newStock;
-      wh.stok = newStock;
-      wh.hargaRataRata = newWac;
-    });
-  }
-
-  if (payload.status === 'pending' && purchase.status === 'completed') {
-    purchase.status = 'pending';
-    purchase.items.forEach((item: any) => {
-      const wh = (db.warehouse as any)[item.bahanBakuId];
-      wh.stok = item.prev.stok;
-      wh.hargaRataRata = item.prev.wac;
-    });
-  }
-}
-
+// Supabase mock handling basic operations
 mock.module('@/integrations/supabase/client', () => {
   return {
     supabase: {
       from: (table: string) => ({
+        select: () => ({
+          eq: (_col: string, val: any) => ({
+            eq: (_col2: string, _val2: any) => ({
+              single: () => {
+                if (table === 'purchases') {
+                  return Promise.resolve({ data: (db.purchases as any)[val], error: null });
+                }
+                if (table === 'bahan_baku') {
+                  const item = (db.warehouse as any)[val];
+                  if (!item) return Promise.resolve({ data: null, error: { message: 'not found' } });
+                  return Promise.resolve({
+                    data: {
+                      id: item.id,
+                      stok: item.stok,
+                      harga_rata_rata: item.hargaRataRata,
+                      harga_satuan: item.hargaSatuan ?? item.hargaRataRata
+                    },
+                    error: null
+                  });
+                }
+                return Promise.resolve({ data: null, error: null });
+              }
+            })
+          })
+        }),
         update: (payload: any) => ({
-          eq: (col: string, val: any) => ({
-            eq: (col2: string, val2: any) => {
-              applyUpdate(table, payload, { [col]: val, [col2]: val2 });
+          eq: (_col: string, val: any) => ({
+            eq: (_col2: string, _val2: any) => {
+              if (table === 'purchases') {
+                const purchase = (db.purchases as any)[val];
+                if (purchase) purchase.status = payload.status;
+              } else if (table === 'bahan_baku') {
+                const wh = (db.warehouse as any)[val];
+                if (wh) {
+                  if (typeof payload.stok === 'number') wh.stok = payload.stok;
+                  if (typeof payload.harga_rata_rata === 'number') wh.hargaRataRata = payload.harga_rata_rata;
+                  if (typeof payload.harga_satuan === 'number') wh.hargaSatuan = payload.harga_satuan;
+                }
+              }
               return Promise.resolve({ data: null, error: null });
             }
           })
-        })
+        }),
+        insert: (payload: any) => {
+          if (table === 'bahan_baku') {
+            (db.warehouse as any)[payload.id] = {
+              id: payload.id,
+              stok: payload.stok,
+              hargaRataRata: payload.harga_rata_rata,
+              hargaSatuan: payload.harga_satuan
+            };
+          }
+          return Promise.resolve({ data: null, error: null });
+        }
       })
     }
   };
@@ -97,3 +115,4 @@ describe('Purchase-Warehouse Sync', () => {
     expect(db.warehouse.item1.hargaRataRata).toBe(1000);
   });
 });
+

--- a/src/components/warehouse/services/warehouseSyncService.ts
+++ b/src/components/warehouse/services/warehouseSyncService.ts
@@ -288,7 +288,8 @@ export class WarehouseSyncService {
           const percentDiff = priceDiff / item.harga_satuan;
           
           if (percentDiff > 1.0) { // > 100% difference
-            itemIssues.push(`Harga rata-rata sangat berbeda dari harga satuan (${percentDiff * 100:.1f}%)`);
+            const percentLabel = (percentDiff * 100).toFixed(1);
+            itemIssues.push(`Harga rata-rata sangat berbeda dari harga satuan (${percentLabel}%)`);
             suggestions.push('Periksa data pembelian atau update harga satuan');
             severity = 'medium';
           }


### PR DESCRIPTION
## Ringkasan
- sinkronisasi manual stok dan WAC ketika status pembelian berubah
- perbaikan mock Supabase untuk pengujian sinkronisasi pembelian-gudang
- perbaikan format persentase di layanan sinkronisasi gudang

## Pengujian
- `bun test src/components/purchase/__tests__/purchaseWarehouseSync.test.ts`
- `bun test` *(gagal: beberapa kasus pada warehouseCalculations.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fde173f8832eac0653c862ea5b64