### PR TITLE
Perbaiki konsistensi layout AppSidebar

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -203,13 +203,12 @@ export function AppSidebar() {
           '--active-text': '#c2410c', // orange-700
         }}
         className={cn(
-          "w-full justify-start px-3 py-2 transition-all duration-200 relative group",
+          "w-full justify-start px-3 py-2 gap-3 transition-all duration-200 relative group group-data-[collapsible=icon]:px-2 group-data-[collapsible=icon]:py-2 group-data-[collapsible=icon]:gap-0",
           "[&:hover]:!bg-orange-50 [&:hover]:!text-orange-600 hover:scale-[1.02]",
           "[&:active]:!bg-orange-200 [&:active]:!text-orange-700 active:scale-[0.98]",
           "[&:focus]:!bg-orange-100 [&:focus]:!text-orange-600",
           isActive && "!bg-orange-100 !text-orange-600 !border-orange-200"
         )}
-        title={item.title} // Native tooltip
       >
         {/* ✅ NEW: Use UpdateBadge for Updates menu */}
         {isUpdatesMenu ? (
@@ -217,9 +216,9 @@ export function AppSidebar() {
         ) : (
           <item.icon className="h-5 w-5 flex-shrink-0" />
         )}
-        <span className="ml-3 group-data-[collapsible=icon]:hidden">{item.title}</span>
+        <span className="group-data-[collapsible=icon]:hidden">{item.title}</span>
         {/* Tooltip for collapsed state */}
-        <div className="group-data-[collapsible=icon]:peer-hover:opacity-100 group-data-[collapsible=icon]:peer-hover:visible group-data-[collapsible=icon]:peer-hover:left-full group-data-[collapsible=icon]:peer-hover:ml-2 absolute left-0 ml-0 top-1/2 transform -translate-y-1/2 bg-gray-800 text-white text-xs rounded py-1 px-2 opacity-0 invisible transition-all duration-200 z-50 whitespace-nowrap pointer-events-none">
+        <div className="group-data-[collapsible=icon]:group-hover:opacity-100 group-data-[collapsible=icon]:group-hover:visible group-data-[collapsible=icon]:group-hover:left-full group-data-[collapsible=icon]:group-hover:ml-2 absolute left-0 ml-0 top-1/2 transform -translate-y-1/2 bg-gray-800 text-white text-xs rounded py-1 px-2 opacity-0 invisible transition-none z-50 whitespace-nowrap pointer-events-none">
           {item.title}
           <div className="absolute left-0 top-1/2 transform -translate-y-1/2 -ml-1 w-2 h-2 bg-gray-800 rotate-45"></div>
         </div>
@@ -238,18 +237,17 @@ export function AppSidebar() {
         '--active-text': '#c2410c', // orange-700
       }}
       className={cn(
-        "w-full justify-start px-3 py-2 transition-all duration-200 group",
+        "w-full justify-start px-3 py-2 gap-3 transition-all duration-200 group group-data-[collapsible=icon]:px-2 group-data-[collapsible=icon]:py-2 group-data-[collapsible=icon]:gap-0",
         "[&:hover]:!bg-orange-50 [&:hover]:!text-orange-600 hover:scale-[1.02]",
         "[&:active]:!bg-orange-200 [&:active]:!text-orange-700 active:scale-[0.98]",
         "[&:focus]:!bg-orange-100 [&:focus]:!text-orange-600",
         className
       )}
-      title={text} // Native tooltip
     >
       <IconComponent className="h-5 w-5 flex-shrink-0" />
-      <span className="ml-3 group-data-[collapsible=icon]:hidden">{text}</span>
+      <span className="group-data-[collapsible=icon]:hidden">{text}</span>
       {/* Tooltip for collapsed state */}
-      <div className="group-data-[collapsible=icon]:peer-hover:opacity-100 group-data-[collapsible=icon]:peer-hover:visible group-data-[collapsible=icon]:peer-hover:left-full group-data-[collapsible=icon]:peer-hover:ml-2 absolute left-0 ml-0 top-1/2 transform -translate-y-1/2 bg-gray-800 text-white text-xs rounded py-1 px-2 opacity-0 invisible transition-all duration-200 z-50 whitespace-nowrap pointer-events-none">
+      <div className="group-data-[collapsible=icon]:group-hover:opacity-100 group-data-[collapsible=icon]:group-hover:visible group-data-[collapsible=icon]:group-hover:left-full group-data-[collapsible=icon]:group-hover:ml-2 absolute left-0 ml-0 top-1/2 transform -translate-y-1/2 bg-gray-800 text-white text-xs rounded py-1 px-2 opacity-0 invisible transition-none z-50 whitespace-nowrap pointer-events-none">
         {text}
         <div className="absolute left-0 top-1/2 transform -translate-y-1/2 -ml-1 w-2 h-2 bg-gray-800 rotate-45"></div>
       </div>


### PR DESCRIPTION
## Ringkasan
- Samakan padding dan posisi ikon sidebar baik saat normal maupun collapse
- Hilangkan jeda tooltip dan tampilkan nama menu seketika saat hover

## Pengujian
- `npm run lint` (gagal: 702 errors, 102 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68a6069875ec832eb03ef387b7970904