### PR TITLE
Gabungkan impor tipe resep

### DIFF
--- a/src/components/recipe/components/RecipeForm/IngredientsStep.tsx
+++ b/src/components/recipe/components/RecipeForm/IngredientsStep.tsx
@@ -21,9 +21,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { 
-  Plus, 
-  Trash2, 
+import {
+  Plus,
+  Trash2,
   ShoppingCart,
   Calculator,
   Info,
@@ -32,9 +32,13 @@ import {
   Package
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { RECIPE_UNITS } from '../../types';
+import {
+  RECIPE_UNITS,
+  type NewRecipe,
+  type RecipeFormStepProps,
+  type BahanResep,
+} from '../../types';
 import { formatCurrency } from '../../services/recipeUtils';
-import type { NewRecipe, RecipeFormStepProps, BahanResep } from '../../types';
 import { logger } from '@/utils/logger';
 
 // Import warehouse related hooks/services


### PR DESCRIPTION
## Ringkasan
- satukan `RECIPE_UNITS` dan tipe `NewRecipe`, `RecipeFormStepProps`, serta `BahanResep` dalam satu impor dari `../../types`

## Pengujian
- `npm test` *(missing script: "test")*
- `npm run lint` *(gagal: 804 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a68d058fd8832e994a7f5d0efe9ba8