### PR TITLE
refactor: gabungkan import tipe pada BasicInfoStep

### DIFF
--- a/src/components/recipe/components/RecipeForm/BasicInfoStep.tsx
+++ b/src/components/recipe/components/RecipeForm/BasicInfoStep.tsx
@@ -22,10 +22,9 @@ import {
   Plus,
   Info
 } from 'lucide-react';
-import { RECIPE_CATEGORIES } from '../../types';
-import type { NewRecipe, RecipeFormStepProps } from '../../types';
+import { RECIPE_CATEGORIES, type NewRecipe, type RecipeFormStepProps } from '../../types';
 
-interface BasicInfoStepProps extends Omit<RecipeFormStepProps, 'onNext' | 'onPrevious'> {}
+type BasicInfoStepProps = Omit<RecipeFormStepProps, 'onNext' | 'onPrevious'>;
 
 const BasicInfoStep: React.FC<BasicInfoStepProps> = ({
   data,
@@ -39,7 +38,7 @@ const BasicInfoStep: React.FC<BasicInfoStepProps> = ({
   // Get available categories including existing ones from data
   const availableCategories = [
     ...RECIPE_CATEGORIES,
-    ...(data.kategoriResep && !RECIPE_CATEGORIES.includes(data.kategoriResep as any) 
+    ...(data.kategoriResep && !RECIPE_CATEGORIES.includes(data.kategoriResep as string)
       ? [data.kategoriResep] 
       : []
     )


### PR DESCRIPTION
## Ringkasan
- satukan `RECIPE_CATEGORIES`, `NewRecipe`, dan `RecipeFormStepProps` dalam satu import
- rapikan deklarasi tipe dan hilangkan `any` agar sesuai lint

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `npx eslint src/components/recipe/components/RecipeForm/BasicInfoStep.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a68d017d50832eb2b19aa3133eb73e