### PR TITLE
Gabungkan import utilitas resep di RecipeAnalytics

### DIFF
--- a/src/components/orders/components/RecipeAnalytics.tsx
+++ b/src/components/orders/components/RecipeAnalytics.tsx
@@ -12,8 +12,7 @@ import {
   Target,
   Award
 } from 'lucide-react';
-import type { Order } from '../types';
-import { calculateRecipeStats, getRecipeUsageByOrder } from '../types';
+import { type Order, calculateRecipeStats, getRecipeUsageByOrder } from '../types';
 
 interface RecipeAnalyticsProps {
   orders: Order[];


### PR DESCRIPTION
## Ringkasan
- refactor impor `Order`, `calculateRecipeStats`, dan `getRecipeUsageByOrder` ke dalam satu baris.

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a68cfc7984832e8394f0b5097ce3dd