### PR TITLE
refactor: combine profit analysis imports

### DIFF
--- a/src/components/profitAnalysis/index.ts
+++ b/src/components/profitAnalysis/index.ts
@@ -136,12 +136,14 @@ export type {
 } from './utils/profitCalculations';
 
 // ===== CONVENIENT DEFAULT EXPORT =====
-import { ProfitAnalysisProvider } from './contexts/ProfitAnalysisContext';
+import {
+  ProfitAnalysisProvider,
+  PROFIT_ANALYSIS_QUERY_KEYS,
+} from './contexts/ProfitAnalysisContext';
 import { useProfitAnalysis } from './hooks/useProfitAnalysis';
 import ProfitDashboard from './components/ProfitDashboard';
 import profitAnalysisApi from './services/profitAnalysisApi';
 import { PROFIT_CONSTANTS } from './constants/profitConstants';
-import { PROFIT_ANALYSIS_QUERY_KEYS } from './contexts/ProfitAnalysisContext';
 
 // Default export untuk kemudahan penggunaan
 export default {


### PR DESCRIPTION
## Summary
- consolidate ProfitAnalysisProvider and query keys into single import

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 804 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a68cf42ee4832ebfa6eab25d5c0850