### PR TITLE
refactor: satukan import React dan lazy

### DIFF
--- a/src/components/promoCalculator/calculator/index.tsx
+++ b/src/components/promoCalculator/calculator/index.tsx
@@ -6,8 +6,7 @@
  * Dependencies reduced from 5 to 3
  */
 
-import { lazy } from 'react';
-import React from 'react'; // ⚠️ HARUS DITAMBAHKAN
+import React, { lazy } from 'react'; // ⚠️ HARUS DITAMBAHKAN
 
 // ✅ CORE CALCULATOR COMPONENTS: Always needed
 export { default as PromoCalculator } from './PromoCalculator';


### PR DESCRIPTION
## Ringkasan
- Satukan import `React` dan `lazy` dalam satu baris pada promo calculator

## Pengujian
- `pnpm exec eslint src/components/promoCalculator/calculator/index.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a6903f9908832e9617b8113119fbc0