### PR TITLE
Perbaiki import Slot di komponen Button

### DIFF
--- a/supabase-ui/src/components/ui/button.tsx
+++ b/supabase-ui/src/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Slot } from "react"
+import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"


### PR DESCRIPTION
## Ringkasan
- Pindahkan `Slot` ke modul `@radix-ui/react-slot` agar tidak lagi diimpor dari `react`

## Pengujian
- `npm test` *(gagal: Missing script "test")*
- `npm run lint` *(gagal: ✖ 802 problems (700 errors, 102 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a6905c38c4832e8dd37307252b9853