### PR TITLE
feat: gunakan pemuatan dinamis untuk dialog pesanan

### DIFF
--- a/src/components/orders/components/OrderDialogs.tsx
+++ b/src/components/orders/components/OrderDialogs.tsx
@@ -10,56 +10,11 @@ import { DialogLoader } from './shared/LoadingStates';
 
 import { logger } from '@/utils/logger';
 
-// ✅ OPTIMIZED: Lazy loading with better error boundaries
-const OrderForm = React.lazy(() => 
-  import('./dialogs/OrderForm').catch(() => ({
-    default: () => (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-white p-6 rounded-lg max-w-md">
-          <div className="text-red-500 text-lg mb-2">❌ Gagal memuat form pesanan</div>
-          <p className="text-gray-600 mb-4">Form tidak dapat dimuat. Silakan coba lagi.</p>
-          <button 
-            onClick={() => window.location.reload()} 
-            className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
-          >
-            Muat Ulang
-          </button>
-        </div>
-      </div>
-    )
-  }))
-);
-
-const FollowUpTemplateManager = React.lazy(() => 
-  import('./dialogs/FollowUpTemplateManager').catch(() => ({
-    default: () => (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-white p-6 rounded-lg max-w-md">
-          <div className="text-red-500 text-lg mb-2">❌ Gagal memuat template manager</div>
-          <p className="text-gray-600 mb-4">Template manager tidak dapat dimuat.</p>
-          <button 
-            onClick={() => window.location.reload()} 
-            className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
-          >
-            Muat Ulang
-          </button>
-        </div>
-      </div>
-    )
-  }))
-);
-
-const BulkDeleteDialog = React.lazy(() => 
-  import('./dialogs/BulkDeleteDialog').catch(() => ({
-    default: () => null
-  }))
-);
-
-const BulkEditDialog = React.lazy(() => 
-  import('./dialogs/BulkEditDialog').catch(() => ({
-    default: () => null
-  }))
-);
+// ✅ OPTIMIZED: Lazy loading sederhana untuk dialog
+const OrderForm = React.lazy(() => import('./dialogs/OrderForm'));
+const FollowUpTemplateManager = React.lazy(() => import('./dialogs/FollowUpTemplateManager'));
+const BulkDeleteDialog = React.lazy(() => import('./dialogs/BulkDeleteDialog'));
+const BulkEditDialog = React.lazy(() => import('./dialogs/BulkEditDialog'));
 
 // ❌ REMOVED: Unnecessary imports - already optimized
 

--- a/src/components/orders/components/dialogs/index.ts
+++ b/src/components/orders/components/dialogs/index.ts
@@ -7,13 +7,8 @@
  */
 
 // ✅ ESSENTIAL DIALOGS: Core dialog components
-export { default as OrderForm } from './OrderForm';
-export { default as BulkDeleteDialog } from './BulkDeleteDialog';
-export { default as BulkEditDialog } from './BulkEditDialog';
-export { default as FollowUpTemplateManager } from './FollowUpTemplateManager';
-
-// ❌ NOT CHANGED: These are the core dialogs, all are essential
-// For lazy loading, import directly in parent components:
+// Direct exports dihapus untuk mendorong pemuatan dinamis.
+// Gunakan React.lazy di komponen induk:
 // const OrderForm = React.lazy(() => import('./dialogs/OrderForm'));
 
 // ✅ DIALOG GROUPS: For batch loading when needed


### PR DESCRIPTION
## Ringkasan
- hapus ekspor langsung pada barrel `dialogs`
- gunakan `React.lazy` di `OrderDialogs` untuk memuat dialog secara dinamis

## Pengujian
- `pnpm exec eslint src/components/orders/components/dialogs/index.ts src/components/orders/components/OrderDialogs.tsx`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a699a5fa6c832e9f4ee06f8d164769