### PR TITLE
Hapus emoji pada kalkulator overhead

### DIFF
--- a/src/components/operational-costs/OperationalCostPage.tsx
+++ b/src/components/operational-costs/OperationalCostPage.tsx
@@ -169,7 +169,7 @@ const OperationalCostContent: React.FC = () => {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Calculator className="h-5 w-5 text-orange-600" />
-              🧮 Kalkulator Overhead
+              Kalkulator Overhead
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">


### PR DESCRIPTION
## Ringkasan
- Hapus ikon emoji kalkulator pada bagian kalkulator overhead di halaman biaya operasional.

## Pengujian
- `npm test` (gagal: Missing script "test")
- `npm run lint` (gagal: 700 errors, 102 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68a6c7eedb18832ebac1cdc424cff543