### PR TITLE
Sinkronkan kategori bahan baku dengan analisis profit

### DIFF
--- a/src/components/warehouse/components/WarehouseFilters.tsx
+++ b/src/components/warehouse/components/WarehouseFilters.tsx
@@ -20,6 +20,8 @@ import { warehouseApi } from '../services/warehouseApi';
 import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/utils/logger';
 import type { FilterState } from '../types';
+// Kategori default sinkron dengan analisis profit
+import { FNB_COGS_CATEGORIES } from '@/components/profitAnalysis/constants/profitConstants';
 
 interface WarehouseFiltersProps {
   searchTerm: string;
@@ -53,11 +55,12 @@ const fetchCategories = async (): Promise<string[]> => {
     });
     
     const items = await service.fetchBahanBaku();
-    const categories = [...new Set(items.map(item => item.kategori).filter(Boolean))];
+    let categories = [...new Set(items.map(item => item.kategori).filter(Boolean))];
+    if (categories.length === 0) categories = [...FNB_COGS_CATEGORIES];
     return categories.sort();
   } catch (error) {
     logger.error('Failed to fetch categories:', error);
-    return [];
+    return [...FNB_COGS_CATEGORIES];
   }
 };
 

--- a/src/components/warehouse/dialogs/AddEditDialog.tsx
+++ b/src/components/warehouse/dialogs/AddEditDialog.tsx
@@ -9,6 +9,8 @@ import { supabase } from '@/integrations/supabase/client';
 import { warehouseUtils } from '../services/warehouseUtils';
 import { logger } from '@/utils/logger';
 import type { BahanBakuFrontend } from '../types';
+// Gunakan kategori HPP yang sama dengan analisis profit
+import { FNB_COGS_CATEGORIES } from '@/components/profitAnalysis/constants/profitConstants';
 
 interface AddEditDialogProps {
   isOpen: boolean;
@@ -59,10 +61,14 @@ const fetchDialogData = async (type: 'categories' | 'suppliers'): Promise<string
     const service = await warehouseApi.createService('crud', { userId: user?.id });
     const items = await service.fetchBahanBaku();
     const field = type === 'categories' ? 'kategori' : 'supplier';
-    return [...new Set(items.map(item => item[field]).filter(Boolean))].sort();
+    let values = [...new Set(items.map(item => item[field]).filter(Boolean))];
+    if (type === 'categories' && values.length === 0) {
+      values = [...FNB_COGS_CATEGORIES];
+    }
+    return values.sort();
   } catch (error) {
     logger.error(`Failed to fetch ${type}:`, error);
-    return [];
+    return type === 'categories' ? [...FNB_COGS_CATEGORIES] : [];
   }
 };
 

--- a/src/components/warehouse/hooks/useImportExport.ts
+++ b/src/components/warehouse/hooks/useImportExport.ts
@@ -3,6 +3,8 @@ import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
 import type { BahanBakuImport } from '../types';
 import { headerMap, requiredFields, validate, loadXLSX } from '../dialogs/import-utils';
+// Sinkronkan kategori dengan analisis profit
+import { FNB_COGS_CATEGORIES } from '@/components/profitAnalysis/constants/profitConstants';
 
 interface UseImportExportProps {
   onImport: (data: BahanBakuImport[]) => Promise<boolean>;
@@ -186,7 +188,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
       const template = [
         {
           nama: 'Tepung Terigu Premium',
-          kategori: 'Bahan Dasar',
+          kategori: FNB_COGS_CATEGORIES[0],
           supplier: 'PT Supplier Terpercaya',
           satuan: 'gram',
           expiry: '2024-12-31',
@@ -199,7 +201,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
         },
         {
           nama: 'Gula Pasir Halus',
-          kategori: 'Pemanis',
+          kategori: FNB_COGS_CATEGORIES[1],
           supplier: 'CV Gula Manis',
           satuan: 'gram',
           expiry: '2024-11-30',
@@ -212,7 +214,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
         },
         {
           nama: 'Minyak Goreng',
-          kategori: 'Minyak',
+          kategori: FNB_COGS_CATEGORIES[2],
           supplier: 'PT Minyak Sehat',
           satuan: 'ml',
           expiry: '2025-06-15',
@@ -261,7 +263,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
       const template = [
         {
           nama: 'Tepung Terigu Premium',
-          kategori: 'Bahan Dasar',
+          kategori: FNB_COGS_CATEGORIES[0],
           supplier: 'PT Supplier Terpercaya',
           satuan: 'gram',
           expiry: '2024-12-31',
@@ -274,7 +276,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
         },
         {
           nama: 'Gula Pasir Halus',
-          kategori: 'Pemanis',
+          kategori: FNB_COGS_CATEGORIES[1],
           supplier: 'CV Gula Manis',
           satuan: 'gram',
           expiry: '2024-11-30',
@@ -287,7 +289,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
         },
         {
           nama: 'Minyak Goreng',
-          kategori: 'Minyak',
+          kategori: FNB_COGS_CATEGORIES[2],
           supplier: 'PT Minyak Sehat',
           satuan: 'ml',
           expiry: '2025-06-15',

--- a/src/components/warehouse/hooks/useWarehouseCore.ts
+++ b/src/components/warehouse/hooks/useWarehouseCore.ts
@@ -4,6 +4,8 @@ import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
 import { useSupplier } from '@/contexts/SupplierContext';
+// Gunakan kategori yang sama dengan analisis profit
+import { FNB_COGS_CATEGORIES } from '@/components/profitAnalysis/constants/profitConstants';
 
 // Types - Updated to use BahanBakuFrontend consistently
 import type { BahanBakuFrontend, FilterState, SortConfig } from '../types';
@@ -118,6 +120,10 @@ export const useWarehouseCore = (context: WarehouseContextType) => {
   const availableCategories = useMemo(() => {
     const categories = new Set(context.bahanBaku.map(item => item.kategori).filter(Boolean));
     const result = Array.from(categories);
+    if (result.length === 0) {
+      logger.debug(`[${hookId.current}] 📊 Using default FNB categories`);
+      return [...FNB_COGS_CATEGORIES];
+    }
     logger.debug(`[${hookId.current}] 📊 Available categories:`, result);
     return result;
   }, [context.bahanBaku]);

--- a/src/components/warehouse/services/warehouseUtils.ts
+++ b/src/components/warehouse/services/warehouseUtils.ts
@@ -3,6 +3,8 @@ import type { BahanBakuFrontend, FilterState, SortConfig, ValidationResult } fro
 
 import { warehouseUtils } from '@/components/warehouse/services';
 import { logger } from '@/utils/logger';
+// Default kategori untuk sinkron dengan analisis profit
+import { FNB_COGS_CATEGORIES } from '@/components/profitAnalysis/constants/profitConstants';
 
 /**
  * Get effective unit price using weighted average cost (WAC) if available
@@ -88,7 +90,10 @@ export const warehouseUtils = {
     });
   },
 
-  getUniqueCategories: (items: BahanBakuFrontend[]) => Array.from(new Set(items.map(i => i.kategori).filter(Boolean))).sort(),
+  getUniqueCategories: (items: BahanBakuFrontend[]) => {
+    const categories = Array.from(new Set(items.map(i => i.kategori).filter(Boolean)));
+    return categories.length > 0 ? categories.sort() : [...FNB_COGS_CATEGORIES];
+  },
   getUniqueSuppliers:  (items: BahanBakuFrontend[]) => Array.from(new Set(items.map(i => i.supplier).filter(Boolean))).sort(),
 
   getLowStockItems: (items: BahanBakuFrontend[]) => items.filter(i => i.stok <= i.minimum),


### PR DESCRIPTION
## Ringkasan
- sinkronisasi kategori bahan baku dengan konstanta `FNB_COGS_CATEGORIES` dari modul analisis profit
- fallback kategori bawaan bila gudang belum memiliki data

## Pengujian
- `npm test` *(gagal: Missing script: "test")*
- `npm run lint` *(gagal: 802 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cadf8684832e9e529984978d1323