### PR TITLE
Perbaiki sinkronisasi rentang tanggal di Profit Analysis

### DIFF
--- a/src/components/profitAnalysis/hooks/useProfitAnalysis.ts
+++ b/src/components/profitAnalysis/hooks/useProfitAnalysis.ts
@@ -404,6 +404,17 @@ export const useProfitAnalysis = (
     }
   }, []); // No dependencies needed
 
+  // Muat ulang riwayat profit saat rentang tanggal berubah
+  useEffect(() => {
+    if (!dateRange?.from || !dateRange?.to) return;
+
+    loadProfitHistory({
+      from: dateRange.from,
+      to: dateRange.to,
+      period_type: mode === 'yearly' ? 'yearly' : 'monthly'
+    });
+  }, [dateRange, loadProfitHistory, mode]);
+
   const refreshAnalysis = useCallback(async () => {
     logger.info('🔄 Refreshing profit analysis');
     try {


### PR DESCRIPTION
## Ringkasan
- muat ulang riwayat profit saat rentang tanggal diganti

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `npx eslint .` (gagal: 802 problems)

------
https://chatgpt.com/codex/tasks/task_e_68a6cc96188c832e83ae9f73f48d78d5