### PR TITLE
Fix category existence check when adding recipe categories

### DIFF
--- a/src/components/recipe/services/categoryService.ts
+++ b/src/components/recipe/services/categoryService.ts
@@ -78,7 +78,8 @@ export const addCategory = async (
     }
     
     // Check if category already exists
-    if (categoryExists(trimmedName, recipes)) {
+    const existingCategories = getAllAvailableCategories(recipes);
+    if (categoryExists(trimmedName, existingCategories)) {
       return { success: false, message: 'Kategori dengan nama ini sudah ada' };
     }
     


### PR DESCRIPTION
## Summary
- prevent runtime error by checking existing categories correctly when adding recipe categories

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 800 problems, 698 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a704708c1c832eb6077d3349918f17