### PR TITLE
feat: tambahkan deskripsi dialog pada DateRangePicker

### DIFF
--- a/src/components/ui/DateRangePicker.tsx
+++ b/src/components/ui/DateRangePicker.tsx
@@ -166,6 +166,9 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
         <DialogContent className="w-[95vw] max-w-md p-0">
           <DialogHeader className="px-4 py-3 border-b">
             <DialogTitle>Pilih Rentang Tanggal</DialogTitle>
+            <DialogDescription>
+              Pilih rentang tanggal untuk memfilter data.
+            </DialogDescription>
           </DialogHeader>
           <PresetButtons />
           <div className="p-4">


### PR DESCRIPTION
## Ringkasan
- tambahkan `DialogDescription` pada `DateRangePicker` untuk memenuhi aksesibilitas Radix

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `npm run lint` (gagal: Unexpected any, require() import, lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a7036ab5a4832ebc6db765e543cebf