### PR TITLE
feat: aktifkan bulk delete untuk gudang

### DIFF
--- a/src/components/warehouse/WarehousePage.tsx
+++ b/src/components/warehouse/WarehousePage.tsx
@@ -127,7 +127,7 @@ const updateWarehouseItem = async ({ id, item }: { id: string; item: Partial<Bah
 const deleteWarehouseItem = async (id: string): Promise<void> => {
   try {
     const service = await getCrudService();
-    
+
     const success = await service.deleteBahanBaku(id);
     if (!success) {
       throw new Error('Failed to delete item');
@@ -138,14 +138,15 @@ const deleteWarehouseItem = async (id: string): Promise<void> => {
   }
 };
 
-const bulkDeleteWarehouseItems = async (ids: string[]): Promise<void> => {
+const bulkDeleteWarehouseItems = async (ids: string[]): Promise<boolean> => {
   try {
     const service = await getCrudService();
-    
+
     const success = await service.bulkDeleteBahanBaku(ids);
     if (!success) {
       throw new Error('Failed to bulk delete items');
     }
+    return true;
   } catch (error) {
     logger.error('Failed to bulk delete warehouse items:', error);
     throw new Error(`Failed to bulk delete items: ${error}`);
@@ -372,7 +373,15 @@ const WarehousePageContent: React.FC = () => {
         return false;
       }
     },
-    // Note: bulkDeleteBahanBaku will be handled by fallback to individual deletes
+    bulkDeleteBahanBaku: async (ids: string[]) => {
+      try {
+        await bulkDeleteWarehouseItems(ids);
+        return true;
+      } catch (error) {
+        logger.error('Context bulkDeleteBahanBaku error:', error);
+        return false;
+      }
+    }
   };
   
   const core = useWarehouseCore(context);


### PR DESCRIPTION
## Ringkasan
- tambahkan fungsi `bulkDeleteWarehouseItems` yang mengembalikan boolean
- sambungkan fungsi bulk delete ke konteks gudang

## Pengujian
- `npm run lint` (gagal: banyak error lint bawaan)
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a707f465dc832e87e6ca93939eeabe