### PR TITLE
Perbaiki penentuan periode analisis profit

### DIFF
--- a/src/components/profitAnalysis/constants/profitConstants.ts
+++ b/src/components/profitAnalysis/constants/profitConstants.ts
@@ -2,6 +2,14 @@
 // ==============================================
 // Konstanta untuk analisis profit dalam Bahasa Indonesia
 
+// Helper untuk mendapatkan periode bulan berjalan tanpa masalah zona waktu
+const getCurrentMonth = (): string => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+};
+
 export const PROFIT_CONSTANTS = {
   // Tipe periode analisis
   PERIOD_TYPES: {
@@ -38,7 +46,7 @@ export const PROFIT_CONSTANTS = {
   
   // Periode default
   DEFAULT_PERIODS: {
-    CURRENT_MONTH: new Date().toISOString().slice(0, 7), // "2024-12"
+    CURRENT_MONTH: getCurrentMonth(), // "2024-12"
     MONTHS_TO_ANALYZE: 12, // Analisis 12 bulan terakhir
   },
   

--- a/src/components/profitAnalysis/hooks/useProfitAnalysis.ts
+++ b/src/components/profitAnalysis/hooks/useProfitAnalysis.ts
@@ -24,6 +24,8 @@ import profitAnalysisApi, {
 import { calcHPP } from '../utils/profitCalculations';
 // 🍽️ Import F&B constants
 import { FNB_LABELS } from '../constants/profitConstants';
+// 🔧 Helper untuk periode bulan berjalan tanpa masalah zona waktu
+import { getCurrentPeriod } from '../utils/profitTransformers';
 
 // Query Keys
 export const PROFIT_QUERY_KEYS = {
@@ -96,7 +98,7 @@ export const useProfitAnalysis = (
 ): UseProfitAnalysisReturn => {
   const {
     autoCalculate = true,
-    defaultPeriod = new Date().toISOString().slice(0, 7), // Safe default
+    defaultPeriod = getCurrentPeriod(), // Safe default
     enableRealTime = true,
     // ✅ ADD WAC OPTION DEFAULT
     enableWAC = true,

--- a/src/components/profitAnalysis/services/profitAnalysisApi.ts
+++ b/src/components/profitAnalysis/services/profitAnalysisApi.ts
@@ -23,7 +23,7 @@ import { warehouseApi } from '@/components/warehouse/services/warehouseApi';
 import { operationalCostApi } from '@/components/operational-costs/services/operationalCostApi';
 
 import { calculateRealTimeProfit, calculateMargins, generateExecutiveInsights, getCOGSEfficiencyRating } from '../utils/profitCalculations';
-import { transformToFNBCOGSBreakdown } from '../utils/profitTransformers';
+import { transformToFNBCOGSBreakdown, getCurrentPeriod } from '../utils/profitTransformers';
 // 🍽️ Import F&B constants
 import { FNB_THRESHOLDS, FNB_LABELS } from '../constants/profitConstants';
 
@@ -419,7 +419,9 @@ const generatePeriods = (from: Date, to: Date, periodType: 'monthly' | 'quarterl
 
   while (current <= end) {
     if (periodType === 'monthly') {
-      periods.push(current.toISOString().slice(0, 7)); // YYYY-MM
+      const year = current.getFullYear();
+      const month = String(current.getMonth() + 1).padStart(2, '0');
+      periods.push(`${year}-${month}`); // YYYY-MM
       current.setMonth(current.getMonth() + 1);
     } else if (periodType === 'quarterly') {
       const quarter = Math.floor(current.getMonth() / 3) + 1;
@@ -1042,7 +1044,7 @@ export const profitAnalysisApi = {
    * ✅ Get current month profit analysis
    */
   async getCurrentMonthProfit(): Promise<ProfitApiResponse<RealTimeProfitCalculation>> {
-    const currentPeriod = new Date().toISOString().slice(0, 7);
+    const currentPeriod = getCurrentPeriod();
     return this.calculateProfitAnalysis(currentPeriod, 'monthly');
   },
 

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -65,10 +65,12 @@ interface ProductSale {
   marginPercent?: number;
 }
 
-// ✅ Helper to convert date range to period for profit analysis
+// ✅ Helper to convert date range to period for profit analysis (timezone-safe)
 const dateRangeToPeriod = (dateRange: DateRange): string => {
   const fromDate = new Date(dateRange.from);
-  return fromDate.toISOString().slice(0, 7); // YYYY-MM format
+  const year = fromDate.getFullYear();
+  const month = String(fromDate.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
 };
 
 // 📊 Helper function to calculate previous period
@@ -84,9 +86,16 @@ const getPreviousPeriod = (dateRange: DateRange): DateRange => {
   const previousFrom = new Date(previousTo);
   previousFrom.setDate(previousFrom.getDate() - diffDays + 1);
 
+  const format = (date: Date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
   return {
-    from: previousFrom.toISOString().split('T')[0],
-    to: previousTo.toISOString().split('T')[0]
+    from: format(previousFrom),
+    to: format(previousTo)
   };
 };
 


### PR DESCRIPTION
## Ringkasan
- Pastikan periode bulanan menggunakan zona waktu lokal
- Tambah helper untuk bulan berjalan dan gunakan di berbagai modul
- Sinkronkan konversi rentang tanggal agar tidak mundur satu bulan

## Pengujian
- `npm test` (gagal: Missing script "test")
- `npm run lint` (gagal: 698 errors, 102 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a707d0eec8832ea380046db0e3d784