### PR TITLE
Sesuaikan template follow-up berdasarkan status pesanan

### DIFF
--- a/docs/ORDER_FOLLOW_UP.md
+++ b/docs/ORDER_FOLLOW_UP.md
@@ -32,3 +32,10 @@ Jika template atau nomor telepon tidak tersedia, fungsi akan mengembalikan `null
 - `cancelled`
 
 Setiap status memiliki template default yang dapat disesuaikan melalui **Template Manager** di halaman pesanan.
+
+## Tutorial Singkat Template Manager
+
+1. Buka halaman pesanan dan klik tombol **Template**.
+2. Pilih status pesanan yang ingin diubah kemudian klik ikon pensil.
+3. Ubah pesan sesuai kebutuhan dan tekan **Simpan Template**.
+4. Gunakan tab **Variabel** untuk melihat daftar variabel yang bisa dimasukkan ke dalam pesan.


### PR DESCRIPTION
## Ringkasan
- otomatis memilih template sesuai status pesanan
- menambahkan panduan singkat pada FollowUpTemplateManager dan dokumentasi

## Pengujian
- `npm run lint` (gagal: 698 errors, 103 warnings)
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a70753ad8c832eab13985dc34ccc5e