### PR TITLE
Ganti logo sidebar Monifine oranye

### DIFF
--- a/public/monifine-logo-orange.svg
+++ b/public/monifine-logo-orange.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 46C9 46 6 43 6 40C6 37 9 34 12 34C19 34 19 46 26 46V22L32 28L38 22V46C45 46 45 34 52 34C55 34 58 37 58 40C58 43 55 46 52 46C48 46 44 44 40 40L32 32L24 40C20 44 16 46 12 46Z" fill="#FF7A00"/>
+  <path d="M32 12L26 22L32 28L38 22L32 12Z" fill="#FF7A00"/>
+</svg>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -153,15 +153,11 @@ export function AppSidebar() {
       group-data-[collapsible=icon]:mx-auto
     "
   >
-    <div
-      className="
-        w-10 h-10 bg-gradient-to-r from-orange-500 to-red-500 rounded-lg
-        flex items-center justify-center text-white flex-shrink-0
-        group-data-[collapsible=icon]:mx-auto
-      "
-    >
-      <TrendingUp className="h-6 w-6" />
-    </div>
+    <img
+      src="/monifine-logo-orange.svg"
+      alt="Logo Monifine"
+      className="w-10 h-10 flex-shrink-0 group-data-[collapsible=icon]:mx-auto"
+    />
 
     <div className="ml-3 opacity-100 transition-opacity duration-300 group-data-[collapsible=icon]:hidden">
       <h2 className="text-lg font-bold whitespace-nowrap">HPP by Monifine</h2>


### PR DESCRIPTION
## Ringkasan
- Ganti ikon header sidebar dengan logo Monifine berwarna oranye
- Tambah aset SVG `monifine-logo-orange.svg`

## Pengujian
- `npm test` (gagal: Missing script "test")
- `npm run lint` (gagal: 801 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a718b08498832e801293bb03f2b6b5