### PR TITLE
fix: import Trash2 icon in TableFilters

### DIFF
--- a/src/components/purchase/components/table/TableFilters.tsx
+++ b/src/components/purchase/components/table/TableFilters.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Search, X } from 'lucide-react';
+import { Search, X, Trash2 } from 'lucide-react';
 import { getStatusDisplayText } from '../../utils/purchaseHelpers';
 
 interface TableFiltersProps {


### PR DESCRIPTION
## Ringkasan
- perbaiki kesalahan `ReferenceError: Trash2 is not defined` dengan menambahkan impor ikon Trash2

## Pengujian
- `pnpm run lint` (gagal: 801 masalah linting)


------
https://chatgpt.com/codex/tasks/task_e_68a71e780ce8832e9bc78b02f5bfce13