### PR TITLE
Perbaiki pratinjau import pembelian: pisahkan jumlah-satuan dan hilangkan harga satuan

### DIFF
--- a/src/components/purchase/components/dialogs/PurchaseImportDialog.tsx
+++ b/src/components/purchase/components/dialogs/PurchaseImportDialog.tsx
@@ -114,8 +114,8 @@ const PurchaseImportDialog: React.FC<PurchaseImportDialogProps> = ({
                       Format File yang Dibutuhkan
                     </h4>
                     <p className="text-sm text-blue-800">
-                      Pastikan file Anda memiliki kolom: Tanggal, Supplier, Nama Bahan, Jumlah, Satuan, 
-                      Harga Satuan, Total. Anda dapat mengunduh template di bawah ini.
+                      Pastikan file Anda memiliki kolom: Tanggal, Supplier, Nama Bahan, Jumlah, Satuan,
+                      Total. Anda dapat mengunduh template di bawah ini.
                     </p>
                   </div>
                 </div>
@@ -189,7 +189,7 @@ const PurchaseImportDialog: React.FC<PurchaseImportDialogProps> = ({
                         <th className="px-4 py-2 text-left font-medium text-gray-900 border-b">Supplier</th>
                         <th className="px-4 py-2 text-left font-medium text-gray-900 border-b">Bahan Baku</th>
                         <th className="px-4 py-2 text-left font-medium text-gray-900 border-b">Jumlah</th>
-                        <th className="px-4 py-2 text-left font-medium text-gray-900 border-b">Harga Satuan</th>
+                        <th className="px-4 py-2 text-left font-medium text-gray-900 border-b">Satuan</th>
                         <th className="px-4 py-2 text-left font-medium text-gray-900 border-b">Total</th>
                       </tr>
                     </thead>
@@ -206,15 +206,10 @@ const PurchaseImportDialog: React.FC<PurchaseImportDialogProps> = ({
                             {purchase.items[0]?.nama || '-'}
                           </td>
                           <td className="px-4 py-2 border-b">
-                            {purchase.items[0]?.kuantitas || 0} {purchase.items[0]?.satuan || ''}
+                            {purchase.items[0]?.kuantitas || 0}
                           </td>
                           <td className="px-4 py-2 border-b">
-                            {new Intl.NumberFormat('id-ID', {
-                              style: 'currency',
-                              currency: 'IDR',
-                              minimumFractionDigits: 0,
-                              maximumFractionDigits: 0,
-                            }).format(purchase.items[0]?.hargaSatuan || 0)}
+                            {purchase.items[0]?.satuan || ''}
                           </td>
                           <td className="px-4 py-2 border-b">
                             {new Intl.NumberFormat('id-ID', {

--- a/src/components/purchase/hooks/usePurchaseImport.ts
+++ b/src/components/purchase/hooks/usePurchaseImport.ts
@@ -13,7 +13,6 @@ export interface PurchaseImportData {
     nama: string;
     kuantitas: number;
     satuan: string;
-    hargaSatuan: number;
   }>;
   totalNilai: number;
 }
@@ -51,14 +50,7 @@ const headerMap: Record<string, string> = {
   'satuan': 'satuan',
   'unit': 'satuan',
   'uom': 'satuan',
-  
-  // Price variations
-  'harga_satuan': 'hargaSatuan',
-  'harga': 'hargaSatuan',
-  'unit_price': 'hargaSatuan',
-  'price': 'hargaSatuan',
-  'harga_per_satuan': 'hargaSatuan',
-  
+
   // Total variations
   'total': 'totalNilai',
   'total_nilai': 'totalNilai',
@@ -72,7 +64,6 @@ const requiredFields = [
   'nama',
   'kuantitas',
   'satuan',
-  'hargaSatuan',
   'totalNilai'
 ];
 
@@ -110,10 +101,6 @@ export const usePurchaseImport = ({ onImportComplete }: { onImportComplete: () =
       errors.push('Satuan tidak boleh kosong');
     }
 
-    if (isNaN(data.hargaSatuan) || data.hargaSatuan < 0) {
-      errors.push('Harga satuan tidak valid');
-    }
-
     if (isNaN(data.totalNilai) || data.totalNilai < 0) {
       errors.push('Total nilai tidak valid');
     }
@@ -122,10 +109,12 @@ export const usePurchaseImport = ({ onImportComplete }: { onImportComplete: () =
   };
 
   const downloadTemplate = () => {
-    const csvContent = `tanggal,supplier,nama,jumlah,satuan,harga_satuan,total
-2024-01-15,PT. Maju Jaya,tepung terigu,10,kg,12000,120000
-2024-01-16,CV. Sumber Rejeki,gula pasir,5,kg,15000,75000
-2024-01-17,Toko Bahan Kue,minyak goreng,2,liter,20000,40000`;
+    const csvContent = [
+      'tanggal;supplier;nama;jumlah;satuan;total',
+      '2024-01-15;PT. Maju Jaya;tepung terigu;10;kg;120000',
+      '2024-01-16;CV. Sumber Rejeki;gula pasir;5;kg;75000',
+      '2024-01-17;Toko Bahan Kue;minyak goreng;2;liter;40000'
+    ].join('\n');
 
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
     const link = document.createElement('a');
@@ -253,8 +242,7 @@ export const usePurchaseImport = ({ onImportComplete }: { onImportComplete: () =
             items: [{
               nama: mappedRow.nama,
               kuantitas: parseFloat(mappedRow.kuantitas),
-              satuan: mappedRow.satuan,
-              hargaSatuan: parseFloat(mappedRow.hargaSatuan)
+              satuan: mappedRow.satuan
             }],
             totalNilai: parseFloat(mappedRow.totalNilai)
           });
@@ -305,17 +293,21 @@ export const usePurchaseImport = ({ onImportComplete }: { onImportComplete: () =
             supplierId = supplier.id;
           }
           
-          const purchase = {
-            supplier: supplierId,
-            tanggal: new Date(purchaseData.tanggal),
-            items: purchaseData.items.map(item => ({
-              ...item,
-              subtotal: item.kuantitas * item.hargaSatuan
-            })),
-            totalNilai: purchaseData.totalNilai,
-            metodePerhitungan: 'AVERAGE' as const,
-            status: 'pending' as const
-          };
+            const purchase = {
+              supplier: supplierId,
+              tanggal: new Date(purchaseData.tanggal),
+              items: purchaseData.items.map(item => {
+                const hargaSatuan = purchaseData.totalNilai / item.kuantitas;
+                return {
+                  ...item,
+                  hargaSatuan,
+                  subtotal: hargaSatuan * item.kuantitas
+                };
+              }),
+              totalNilai: purchaseData.totalNilai,
+              metodePerhitungan: 'AVERAGE' as const,
+              status: 'pending' as const
+            };
 
           const success = await addPurchase(purchase);
           if (success) {


### PR DESCRIPTION
## Ringkasan
- Pisahkan kolom jumlah dan satuan pada tabel pratinjau import pembelian.
- Hapus kolom harga satuan dari pratinjau serta penjelasan format file.
- Perbaiki template CSV import agar memakai delimiter titik koma dan tanpa kolom harga satuan.

## Pengujian
- `npm test` – gagal karena skrip test tidak ada.
- `npm run lint` – gagal dengan banyak error linting yang sudah ada.


------
https://chatgpt.com/codex/tasks/task_e_68a71df9514c832ebacb060cfa8fd82a