### PR TITLE
feat: gunakan harga total pada import purchase

### DIFF
--- a/public/templates/purchase-import-template.csv
+++ b/public/templates/purchase-import-template.csv
@@ -1,4 +1,4 @@
 supplier;tanggal;nama;kuantitas;satuan;harga
-PT Contoh;2024-01-01;Gula;10;kg;50000
-PT Contoh;2024-01-01;Tepung;5;kg;30000
+PT Contoh;2024-01-01;Gula;10;kg;500000
+PT Contoh;2024-01-01;Tepung;5;kg;150000
 

--- a/src/components/purchase/components/ImportButton.tsx
+++ b/src/components/purchase/components/ImportButton.tsx
@@ -46,7 +46,7 @@ const ImportButton: React.FC = () => {
 
   const showFormatInfo = () => {
     toast.info(
-      'Format CSV: supplier,tanggal(YYYY-MM-DD),nama,kuantitas,satuan,harga. Pemisah kolom boleh koma atau titik koma.',
+      'Format CSV: supplier,tanggal(YYYY-MM-DD),nama,kuantitas,satuan,harga(total). Pemisah kolom boleh koma atau titik koma.',
     );
   };
   return (

--- a/src/components/purchase/utils/purchaseImport.ts
+++ b/src/components/purchase/utils/purchaseImport.ts
@@ -14,7 +14,7 @@ interface RawRow {
 /**
  * Parse CSV file menjadi array pembelian.
  * Format kolom yang didukung:
- * supplier,tanggal,nama,kuantitas,satuan,harga
+ * supplier,tanggal,nama,kuantitas,satuan,harga(total)
  */
 export async function parsePurchaseCSV(file: File): Promise<ImportedPurchase[]> {
   const text = await file.text();
@@ -74,8 +74,8 @@ export async function parsePurchaseCSV(file: File): Promise<ImportedPurchase[]> 
       nama: r.nama,
       kuantitas: r.kuantitas,
       satuan: r.satuan,
-      hargaSatuan: r.harga,
-      subtotal: r.kuantitas * r.harga,
+      hargaSatuan: r.kuantitas ? r.harga / r.kuantitas : 0,
+      subtotal: r.harga,
     };
     purchase.items.push(item);
     purchase.totalNilai += item.subtotal;


### PR DESCRIPTION
## Ringkasan
- tambahkan kolom harga total pada template CSV import pembelian
- parser CSV kini membaca harga total dan menghitung harga satuan otomatis
- perbarui informasi format CSV pada tombol import

## Testing
- `npm test` (gagal: Missing script "test")
- `npm run lint` (gagal: 802 problems (698 errors, 104 warnings))

------
https://chatgpt.com/codex/tasks/task_e_68a72aa6d984832e800c8dd7c7096ad8