### PR TITLE
Perbaiki state OTP yang hilang

### DIFF
--- a/src/components/EmailAuthPage.tsx
+++ b/src/components/EmailAuthPage.tsx
@@ -48,7 +48,10 @@ const EmailAuthPage: React.FC<EmailAuthPageProps> = ({
   const [authState, setAuthState] = useState<AuthState>('idle');
   const [error, setError] = useState('');
   const [cooldownTime, setCooldownTime] = useState(0);
-  
+
+  // ✅ OTP state
+  const [otp, setOtp] = useState<string[]>(['', '', '', '', '', '']);
+
   // ✅ hCaptcha state
   const [hCaptchaToken, setHCaptchaToken] = useState<string | null>(null);
   const [hCaptchaKey, setHCaptchaKey] = useState(0);


### PR DESCRIPTION
## Ringkasan
- Tambah deklarasi state `otp` pada `EmailAuthPage` untuk mencegah `ReferenceError`

## Pengujian
- `npm test` (gagal: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8752488cc832e86e2069674cc7deb