### PR TITLE
feat: tambah dialog detail pesanan

### DIFF
--- a/src/components/orders/components/OrderDialogs.tsx
+++ b/src/components/orders/components/OrderDialogs.tsx
@@ -15,6 +15,7 @@ const OrderForm = React.lazy(() => import('./dialogs/OrderForm'));
 const FollowUpTemplateManager = React.lazy(() => import('./dialogs/FollowUpTemplateManager'));
 const BulkDeleteDialog = React.lazy(() => import('./dialogs/BulkDeleteDialog'));
 const BulkEditDialog = React.lazy(() => import('./dialogs/BulkEditDialog'));
+const OrderDetailDialog = React.lazy(() => import('./dialogs/OrderDetailDialog'));
 
 // ❌ REMOVED: Unnecessary imports - already optimized
 
@@ -30,6 +31,11 @@ interface OrderDialogsProps {
   showTemplateManager: boolean;
   selectedOrderForTemplate: Order | null;
   onCloseTemplateManager: () => void;
+
+  // Detail dialog
+  showDetailDialog?: boolean;
+  detailOrder?: Order | null;
+  onCloseDetail?: () => void;
   
   // Bulk operations (optional - for future use)
   showBulkDeleteDialog?: boolean;
@@ -53,6 +59,11 @@ const OrderDialogs: React.FC<OrderDialogsProps> = ({
   showTemplateManager,
   selectedOrderForTemplate,
   onCloseTemplateManager,
+
+  // Detail dialog props
+  showDetailDialog = false,
+  detailOrder = null,
+  onCloseDetail,
   
   // Bulk operations props (optional)
   showBulkDeleteDialog = false,
@@ -130,6 +141,17 @@ const OrderDialogs: React.FC<OrderDialogsProps> = ({
             onClose={onCloseTemplateManager}
             order={selectedOrderForTemplate}
             onSendWhatsApp={handleSendWhatsApp}
+          />
+        </Suspense>
+      )}
+
+      {/* ✅ ORDER DETAIL DIALOG: Informasi detail pesanan */}
+      {showDetailDialog && detailOrder && (
+        <Suspense fallback={<DialogLoader message="Memuat detail pesanan..." />}>
+          <OrderDetailDialog
+            open={showDetailDialog}
+            order={detailOrder}
+            onOpenChange={onCloseDetail || (() => {})}
           />
         </Suspense>
       )}

--- a/src/components/orders/components/OrdersPage.tsx
+++ b/src/components/orders/components/OrdersPage.tsx
@@ -87,18 +87,22 @@ interface OrdersPageState {
   dialogs: {
     orderForm: boolean;
     templateManager: boolean;
+    detail: boolean;
   };
   editingOrder: Order | null;
   selectedOrderForTemplate: Order | null;
+  viewingOrder: Order | null;
 }
 
 const initialState: OrdersPageState = {
   dialogs: {
     orderForm: false,
-    templateManager: false
+    templateManager: false,
+    detail: false
   },
   editingOrder: null,
-  selectedOrderForTemplate: null
+  selectedOrderForTemplate: null,
+  viewingOrder: null
 };
 
 const OrdersPage: React.FC = () => {
@@ -229,6 +233,24 @@ const OrdersPage: React.FC = () => {
         ...prev,
         dialogs: { ...prev.dialogs, templateManager: false },
         selectedOrderForTemplate: null
+      }));
+    },
+
+    openDetail: (order: Order) => {
+      logger.component('OrdersPage', 'Opening order detail dialog', { orderId: order.id, nomorPesanan: order.nomorPesanan });
+      setPageState(prev => ({
+        ...prev,
+        dialogs: { ...prev.dialogs, detail: true },
+        viewingOrder: order
+      }));
+    },
+
+    closeDetail: () => {
+      logger.component('OrdersPage', 'Closing order detail dialog');
+      setPageState(prev => ({
+        ...prev,
+        dialogs: { ...prev.dialogs, detail: false },
+        viewingOrder: null
       }));
     }
   }), []);
@@ -477,23 +499,12 @@ const OrdersPage: React.FC = () => {
 
   // ✅ ENHANCED: View detail handler
   const handleViewDetail = useCallback((order: Order) => {
-    logger.component('OrdersPage', 'View detail requested:', { 
-      orderId: order.id, 
-      nomorPesanan: order.nomorPesanan 
+    logger.component('OrdersPage', 'View detail requested:', {
+      orderId: order.id,
+      nomorPesanan: order.nomorPesanan
     });
-    
-    // Set order for template manager (could be used for template preview)
-    setPageState(prev => ({
-      ...prev,
-      selectedOrderForTemplate: order
-    }));
-    
-    // Placeholder for detail view - can be developed further
-    toast.info(`Detail pesanan #${order.nomorPesanan} - Coming soon!`);
-    
-    // TODO: Implement detail modal or navigate to detail page
-    logger.debug('Order detail view - feature coming soon');
-  }, []);
+    dialogHandlers.openDetail(order);
+  }, [dialogHandlers]);
 
   // ✅ DEBUG: Test function for status update (development only)
   const debugStatusUpdate = useCallback(async () => {
@@ -723,9 +734,12 @@ const OrdersPage: React.FC = () => {
           editingOrder={pageState.editingOrder}
           showTemplateManager={pageState.dialogs.templateManager}
           selectedOrderForTemplate={pageState.selectedOrderForTemplate}
+          showDetailDialog={pageState.dialogs.detail}
+          detailOrder={pageState.viewingOrder}
           onSubmitOrder={businessHandlers.submitOrder}
           onCloseOrderForm={dialogHandlers.closeOrderForm}
           onCloseTemplateManager={dialogHandlers.closeTemplateManager}
+          onCloseDetail={dialogHandlers.closeDetail}
         />
       </Suspense>
     </div>

--- a/src/components/orders/components/dialogs/OrderDetailDialog.tsx
+++ b/src/components/orders/components/dialogs/OrderDetailDialog.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { formatCurrency } from '@/utils/formatUtils';
+import { formatDateForDisplay } from '@/utils/unifiedDateUtils';
+import { getStatusText } from '../../constants';
+import type { Order } from '../../types';
+import { logger } from '@/utils/logger';
+
+interface OrderDetailDialogProps {
+  open: boolean;
+  order: Order | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+const OrderDetailDialog: React.FC<OrderDetailDialogProps> = ({ open, order, onOpenChange }) => {
+  if (!order) return null;
+
+  logger.component('OrderDetailDialog', 'Rendering detail dialog', {
+    orderId: order.id,
+    nomorPesanan: order.nomorPesanan,
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Detail Pesanan #{order.nomorPesanan}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm text-gray-600">Pelanggan</p>
+            <p className="text-base font-medium">{order.namaPelanggan}</p>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <p className="text-sm text-gray-600">Tanggal Pesanan</p>
+              <p className="text-base font-medium">{formatDateForDisplay(order.tanggal)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-gray-600">Status</p>
+              <p className="text-base font-medium">{getStatusText(order.status)}</p>
+            </div>
+          </div>
+          {order.items?.length > 0 && (
+            <div>
+              <p className="text-sm text-gray-600 mb-2">Item</p>
+              <ul className="space-y-1">
+                {order.items.map((item, index) => (
+                  <li key={index} className="text-sm flex justify-between">
+                    <span>{item.namaMenu} x{item.jumlah}</span>
+                    <span>{formatCurrency(item.hargaTotal || 0)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <div className="flex justify-between pt-4 border-t">
+            <span className="font-medium">Total</span>
+            <span className="font-semibold">{formatCurrency(order.totalPesanan)}</span>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default OrderDetailDialog;
+


### PR DESCRIPTION
## Ringkasan
- tambahkan `OrderDetailDialog` untuk menampilkan detail pesanan
- integrasikan dialog detail pada `OrderDialogs` dan `OrdersPage`
- catat aktivitas buka/tutup dialog menggunakan `logger`

## Testing
- `npm test` (gagal: Missing script: "test")
- `npm run lint` (gagal: 885 errors, 107 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68abf58c8c44832ebbd9db818ddbdcf0