### PR TITLE
feat(purchase): tambah komponen filter dan statistik

### DIFF
--- a/src/components/purchase/components/PurchaseFilters.tsx
+++ b/src/components/purchase/components/PurchaseFilters.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { PurchaseFilters, PurchaseFiltersProps } from '../types/purchase.types';
+import { getStatusDisplayText } from '../utils/purchaseHelpers';
+
+const PurchaseFilters: React.FC<PurchaseFiltersProps> = ({
+  filters,
+  onChange,
+  suppliers = [],
+  className = '',
+}) => {
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...filters, searchQuery: e.target.value });
+  };
+
+  const handleStatusChange = (value: string) => {
+    onChange({
+      ...filters,
+      statusFilter: value as PurchaseFilters['statusFilter'],
+    });
+  };
+
+  const handleSupplierChange = (value: string) => {
+    onChange({ ...filters, supplierFilter: value === 'all' ? undefined : value });
+  };
+
+  return (
+    <div className={`flex flex-col sm:flex-row gap-4 ${className}`}>
+      <Input
+        placeholder="Cari supplier atau item..."
+        value={filters.searchQuery}
+        onChange={handleSearchChange}
+        className="w-full sm:w-64"
+      />
+
+      <Select value={filters.statusFilter} onValueChange={handleStatusChange}>
+        <SelectTrigger className="w-full sm:w-40">
+          <SelectValue placeholder="Semua Status" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Semua Status</SelectItem>
+          <SelectItem value="pending">{getStatusDisplayText('pending')}</SelectItem>
+          <SelectItem value="completed">{getStatusDisplayText('completed')}</SelectItem>
+          <SelectItem value="cancelled">{getStatusDisplayText('cancelled')}</SelectItem>
+        </SelectContent>
+      </Select>
+
+      {suppliers.length > 0 && (
+        <Select
+          value={filters.supplierFilter || 'all'}
+          onValueChange={handleSupplierChange}
+        >
+          <SelectTrigger className="w-full sm:w-48">
+            <SelectValue placeholder="Semua Supplier" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Semua Supplier</SelectItem>
+            {suppliers.map((s) => (
+              <SelectItem key={s.id} value={s.id}>
+                {s.nama}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </div>
+  );
+};
+
+export default PurchaseFilters;

--- a/src/components/purchase/components/PurchaseStats.tsx
+++ b/src/components/purchase/components/PurchaseStats.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Card } from '@/components/ui/card';
+import { formatCurrency } from '@/utils/formatUtils';
+import { PurchaseStatsProps } from '../types/purchase.types';
+
+const PurchaseStats: React.FC<PurchaseStatsProps> = ({ stats, className = '' }) => {
+  return (
+    <div className={`grid grid-cols-1 md:grid-cols-4 gap-4 ${className}`}>
+      <Card className="p-4">
+        <div className="text-sm text-gray-500">Total Pembelian</div>
+        <div className="text-2xl font-bold">{stats.total}</div>
+      </Card>
+      <Card className="p-4">
+        <div className="text-sm text-gray-500">Total Nilai</div>
+        <div className="text-2xl font-bold">{formatCurrency(stats.totalValue)}</div>
+      </Card>
+      <Card className="p-4">
+        <div className="text-sm text-gray-500">Pending</div>
+        <div className="text-2xl font-bold">{stats.byStatus.pending}</div>
+      </Card>
+      <Card className="p-4">
+        <div className="text-sm text-gray-500">Selesai</div>
+        <div className="text-2xl font-bold">{stats.byStatus.completed}</div>
+      </Card>
+    </div>
+  );
+};
+
+export default PurchaseStats;

--- a/src/components/purchase/components/index.ts
+++ b/src/components/purchase/components/index.ts
@@ -40,13 +40,13 @@ export const PURCHASE_COMPONENTS_LAZY = {
   BulkActionsToolbar: () => import('./BulkActionsToolbar'),
   BulkDeleteDialog: () => import('./BulkDeleteDialog'),
   StatusChangeConfirmationDialog: () => import('./StatusChangeConfirmationDialog'),
-  
+
+  // Utility components
+  PurchaseFilters: () => import('./PurchaseFilters'),
+  PurchaseStats: () => import('./PurchaseStats'),
+
   // Import dialog
   PurchaseImportDialog: () => import('./dialogs/PurchaseImportDialog')
-  
-  // ❌ REMOVED: Components that don't exist yet
-  // PurchaseFilters: () => import('./PurchaseFilters'), // TODO: Create this component
-  // PurchaseStats: () => import('./PurchaseStats')      // TODO: Create this component
 } as const;
 
 // ✅ COMPONENT GROUPS: For batch loading

--- a/src/components/purchase/types/purchase.types.ts
+++ b/src/components/purchase/types/purchase.types.ts
@@ -54,6 +54,11 @@ export interface PurchaseStats {
   completionRate: number;
 }
 
+export interface PurchaseStatsProps {
+  stats: PurchaseStats;
+  className?: string;
+}
+
 // ============ API / DB Shapes ============
 // Baris item untuk disimpan ke DB (snake_case). Ini yang dibaca manual sync.
 export interface PurchaseItemDB {
@@ -161,8 +166,8 @@ export interface PurchaseContextType {
 }
 
 // Hook aliases
-export interface UsePurchaseReturn extends PurchaseContextType {}
-export interface UsePurchaseTableReturn extends PurchaseTableContextType {}
+export type UsePurchaseReturn = PurchaseContextType;
+export type UsePurchaseTableReturn = PurchaseTableContextType;
 
 export interface UsePurchaseStatsReturn {
   stats: PurchaseStats;
@@ -250,6 +255,13 @@ export interface PurchaseFilters {
   supplierFilter?: string;
   sortBy: 'tanggal' | 'totalNilai' | 'supplier' | 'status';
   sortOrder: 'asc' | 'desc';
+}
+
+export interface PurchaseFiltersProps {
+  filters: PurchaseFilters;
+  onChange: (filters: PurchaseFilters) => void;
+  suppliers?: Array<{ id: string; nama: string }>;
+  className?: string;
 }
 
 export interface PaginationState {


### PR DESCRIPTION
## Ringkasan
- tambah komponen `PurchaseFilters` dan `PurchaseStats`
- definisikan tipe props untuk kedua komponen
- daftarkan keduanya di `PURCHASE_COMPONENTS_LAZY`

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `npx eslint src/components/purchase/components/PurchaseFilters.tsx src/components/purchase/components/PurchaseStats.tsx src/components/purchase/types/purchase.types.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abf58e8138832eb790c8afeee850e4