### PR TITLE
feat: tambahkan aksi promo

### DIFF
--- a/src/components/promoCalculator/PromoCalculatorLayout.tsx
+++ b/src/components/promoCalculator/PromoCalculatorLayout.tsx
@@ -6,6 +6,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import PromoCard from './components/PromoCard';
 import { logger } from '@/utils/logger';
 import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
 
 // Import services
 import { promoService } from './services/promoService';
@@ -179,6 +180,17 @@ const PromoCalculatorLayout = () => {
     }
   });
 
+  const createPromoMutation = useMutation({
+    mutationFn: (data) => promoService.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['promos']);
+      toast.success('Promo berhasil diduplikat');
+    },
+    onError: (error) => {
+      toast.error(`Gagal menduplikat promo: ${error.message}`);
+    }
+  });
+
   // Utility functions
   const formatCurrency = (value) => {
     return new Intl.NumberFormat('id-ID', {
@@ -230,7 +242,7 @@ const PromoCalculatorLayout = () => {
   // ✅ Promo action handlers with mutations
   const handleEditPromo = (promo) => {
     logger.context('PromoCalculatorLayout', 'Edit promo:', promo);
-    // TODO: Implement edit functionality - could navigate to calculator with pre-filled data
+    navigate(`/promo/edit/${promo.id}`);
   };
 
   const handleDeletePromo = async (promo) => {
@@ -241,20 +253,23 @@ const PromoCalculatorLayout = () => {
 
   const handleViewPromo = (promo) => {
     logger.context('PromoCalculatorLayout', 'View promo:', promo);
-    // TODO: Implement view functionality - could show detailed modal
+    navigate(`/promo/edit/${promo.id}`);
   };
 
   const handleDuplicatePromo = (promo) => {
     const duplicatedData = {
-      ...promo,
       namaPromo: `${promo.namaPromo} (Copy)`,
+      tipePromo: promo.tipePromo,
       status: 'draft',
-      tanggalMulai: '',
-      tanggalSelesai: ''
+      deskripsi: promo.deskripsi,
+      tanggalMulai: null,
+      tanggalSelesai: null,
+      dataPromo: promo.dataPromo,
+      calculationResult: promo.calculationResult
     };
-    
-    // TODO: Use create mutation to save duplicated promo
+
     logger.context('PromoCalculatorLayout', 'Duplicate promo:', duplicatedData);
+    createPromoMutation.mutate(duplicatedData);
   };
 
   // Enhanced Loading Component


### PR DESCRIPTION
## Ringkasan
- navigasi ke halaman edit saat tombol edit & view ditekan
- duplikat promo disimpan lewat `createPromoMutation`
- tambahkan import `toast` untuk notifikasi

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `npm run lint` (gagal: Unexpected any dan require import di beberapa berkas)


------
https://chatgpt.com/codex/tasks/task_e_68abf590d934832ebbc60e187f0487e2