### PR TITLE
feat: sembunyikan kontrol lazy loading

### DIFF
--- a/src/components/devices/DeviceManagementPage.tsx
+++ b/src/components/devices/DeviceManagementPage.tsx
@@ -43,7 +43,7 @@ const DeviceManagementPage: React.FC = () => {
   // ✅ LAZY LOADING STATE
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [useLazyLoading, setUseLazyLoading] = useState(false);
+  const [useLazyLoading] = useState(true);
   const [paginationInfo, setPaginationInfo] = useState({ totalCount: 0, totalPages: 0 });
   
   // ✅ LAZY LOADING QUERY
@@ -60,7 +60,7 @@ const DeviceManagementPage: React.FC = () => {
       setPaginationInfo({ totalCount: result.totalCount, totalPages: result.totalPages });
       return result;
     },
-    enabled: useLazyLoading && !!user?.id,
+    enabled: !!user?.id,
     staleTime: 30000,
   });
   
@@ -220,7 +220,7 @@ const DeviceManagementPage: React.FC = () => {
           <CardDescription>{errorMessage}</CardDescription>
         </CardHeader>
         <CardContent>
-          <Button onClick={useLazyLoading ? () => refetchPaginated() : handleRefreshDevices}>Coba Lagi</Button>
+          <Button onClick={() => refetchPaginated()}>Coba Lagi</Button>
         </CardContent>
       </Card>
     );
@@ -234,41 +234,27 @@ const DeviceManagementPage: React.FC = () => {
           Kelola perangkat yang saat ini masuk ke akun Anda
         </p>
         
-        {/* ✅ LAZY LOADING CONTROLS */}
+        {/* Kontrol Paginasi */}
         <div className="mt-4 p-4 bg-gray-50 rounded-lg border">
           <div className="flex flex-col space-y-3 md:flex-row md:items-center md:justify-between md:space-y-0">
             <div className="flex items-center space-x-3">
-              <label className="flex items-center space-x-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={useLazyLoading}
-                  onChange={(e) => setUseLazyLoading(e.target.checked)}
-                  className="rounded border-gray-300 text-orange-600 focus:ring-orange-500"
-                />
-                <span className="text-sm font-medium">Aktifkan Lazy Loading</span>
-              </label>
-              
-              {useLazyLoading && (
-                <select
-                  value={itemsPerPage}
-                  onChange={(e) => {
-                    setItemsPerPage(Number(e.target.value));
-                    setCurrentPage(1);
-                  }}
-                  className="px-3 py-1 border border-gray-300 rounded text-sm"
-                >
-                  <option value={5}>5 per halaman</option>
-                  <option value={10}>10 per halaman</option>
-                  <option value={20}>20 per halaman</option>
-                </select>
-              )}
+              <select
+                value={itemsPerPage}
+                onChange={(e) => {
+                  setItemsPerPage(Number(e.target.value));
+                  setCurrentPage(1);
+                }}
+                className="px-3 py-1 border border-gray-300 rounded text-sm"
+              >
+                <option value={5}>5 per halaman</option>
+                <option value={10}>10 per halaman</option>
+                <option value={20}>20 per halaman</option>
+              </select>
             </div>
-            
-            {useLazyLoading && (
-              <div className="text-sm text-gray-600">
-                Total: {paginationInfo.totalCount} perangkat
-              </div>
-            )}
+
+            <div className="text-sm text-gray-600">
+              Total: {paginationInfo.totalCount} perangkat
+            </div>
           </div>
         </div>
       </div>
@@ -528,8 +514,8 @@ const DeviceManagementPage: React.FC = () => {
         </CardContent>
         </Card>
         
-        {/* ✅ PAGINATION CONTROLS */}
-        {useLazyLoading && paginationInfo.totalPages > 1 && (
+        {/* PAGINATION CONTROLS */}
+        {paginationInfo.totalPages > 1 && (
           <Card>
             <CardContent className="pt-6">
               <div className="flex flex-col space-y-4 md:flex-row md:items-center md:justify-between md:space-y-0">

--- a/src/components/financial/components/TransactionTable.tsx
+++ b/src/components/financial/components/TransactionTable.tsx
@@ -205,7 +205,7 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [useLazyLoading, setUseLazyLoading] = useState(false); // Toggle untuk lazy loading
+  const [useLazyLoading] = useState(true);
 
   // ✅ Definisikan user TERLEBIH DAHULU sebelum digunakan
   const { user } = useAuth(); // ✅ Harus di sini
@@ -216,7 +216,7 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
     user?.id, 
     currentPage, 
     itemsPerPage, 
-    useLazyLoading && !legacyTransactions // Gunakan lazy loading hanya jika tidak ada legacy props
+    !legacyTransactions // Gunakan lazy loading hanya jika tidak ada legacy props
   );
   
   const transactions = legacyTransactions || queryData.transactions;
@@ -228,25 +228,22 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
 
   // Pagination logic - gunakan server-side jika lazy loading aktif
   const currentTransactions = useMemo(() => {
-    if (useLazyLoading && paginationInfo && !legacyTransactions) {
-      // Server-side pagination: data sudah dipaginasi dari server
+    if (!legacyTransactions && paginationInfo) {
       return transactions;
     } else {
-      // Client-side pagination: slice data di client
       const firstItem = (currentPage - 1) * itemsPerPage;
       return transactions.slice(firstItem, firstItem + itemsPerPage);
     }
-  }, [transactions, currentPage, itemsPerPage, useLazyLoading, paginationInfo, legacyTransactions]);
+  }, [transactions, currentPage, itemsPerPage, paginationInfo, legacyTransactions]);
 
-  // Calculate pagination info
-  const totalPages = useLazyLoading && paginationInfo 
-    ? paginationInfo.totalPages 
+  const totalPages = !legacyTransactions && paginationInfo
+    ? paginationInfo.totalPages
     : Math.ceil(transactions.length / itemsPerPage);
-  const totalItems = useLazyLoading && paginationInfo 
-    ? paginationInfo.total 
+  const totalItems = !legacyTransactions && paginationInfo
+    ? paginationInfo.total
     : transactions.length;
   const startItem = (currentPage - 1) * itemsPerPage + 1;
-  const endItem = useLazyLoading && paginationInfo 
+  const endItem = !legacyTransactions && paginationInfo
     ? Math.min(currentPage * itemsPerPage, paginationInfo.total)
     : Math.min(currentPage * itemsPerPage, transactions.length);
 
@@ -331,27 +328,7 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
             )}
           </div>
           <div className="flex items-center gap-2">
-            {!legacyTransactions && (
-              <div className="flex items-center gap-2 mr-2">
-                <label className="text-xs text-gray-600 flex items-center gap-1 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={useLazyLoading}
-                    onChange={(e) => {
-                      setUseLazyLoading(e.target.checked);
-                      setCurrentPage(1); // Reset ke halaman pertama
-                    }}
-                    className="w-3 h-3"
-                  />
-                  <span>Lazy Loading</span>
-                </label>
-                {useLazyLoading && (
-                  <div className="text-xs text-blue-600 bg-blue-50 px-2 py-1 rounded">
-                    Server-side
-                  </div>
-                )}
-              </div>
-            )}
+            {/* Kontrol Lazy Loading dihapus */}
             <Button
               variant="outline"
               size="sm"
@@ -375,7 +352,7 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
               Terakhir diperbarui: {lastUpdated.toLocaleString('id-ID')}
             </p>
           )}
-          {useLazyLoading && paginationInfo && (
+          {paginationInfo && (
             <p className="text-xs text-blue-600">
               Mode: Server-side Pagination | Total: {paginationInfo.total} data
             </p>

--- a/src/components/orders/components/OrdersPage.tsx
+++ b/src/components/orders/components/OrdersPage.tsx
@@ -126,7 +126,7 @@ const OrdersPage: React.FC = () => {
   // ✅ LAZY LOADING STATE: State untuk kontrol lazy loading
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [useLazyLoading, setUseLazyLoading] = useState(false);
+  const [useLazyLoading] = useState(true);
   const [paginationInfo, setPaginationInfo] = useState({ totalCount: 0, totalPages: 0 });
 
   // ✅ LAZY LOADING QUERY: Fetch paginated data when lazy loading is enabled
@@ -141,7 +141,7 @@ const OrdersPage: React.FC = () => {
       if (!user?.id) throw new Error('User not authenticated');
       return fetchOrdersPaginated(user.id, currentPage, itemsPerPage);
     },
-    enabled: useLazyLoading && !!user?.id,
+    enabled: !!user?.id,
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
@@ -149,25 +149,25 @@ const OrdersPage: React.FC = () => {
   const { getWhatsappUrl } = useOrderFollowUp();
 
   // ✅ DATA SELECTION: Pilih data berdasarkan mode lazy loading
-  const finalOrders = useLazyLoading ? (paginatedData?.orders || []) : orders;
-  const finalIsLoading = useLazyLoading ? isPaginatedLoading : loading;
-  const finalError = useLazyLoading ? paginatedError : null;
+  const finalOrders = paginatedData?.orders || [];
+  const finalIsLoading = isPaginatedLoading;
+  const finalError = paginatedError;
 
   // ✅ STATS CALCULATION: Hitung statistik berdasarkan data yang dipilih
   const finalStats = useMemo(() => {
-    const dataToUse = useLazyLoading ? (paginatedData?.orders || []) : orders;
+    const dataToUse = paginatedData?.orders || [];
     return {
-      total: useLazyLoading ? paginationInfo.totalCount : orders.length,
+      total: paginationInfo.totalCount,
       totalValue: dataToUse.reduce((sum: number, order: Order) => sum + (order.totalPesanan || 0), 0),
       byStatus: dataToUse.reduce((acc: Record<string, number>, order: Order) => {
         acc[order.status] = (acc[order.status] || 0) + 1;
         return acc;
       }, {} as Record<string, number>),
-      completionRate: dataToUse.length > 0 
+      completionRate: dataToUse.length > 0
         ? Math.round((dataToUse.filter((o: Order) => o.status === 'completed').length / dataToUse.length) * 100)
         : 0
     };
-  }, [useLazyLoading, paginatedData, orders, paginationInfo.totalCount]);
+  }, [paginatedData, paginationInfo.totalCount]);
 
   // ✅ UPDATE PAGINATION INFO: Update when data changes
   React.useEffect(() => {
@@ -662,10 +662,10 @@ const OrdersPage: React.FC = () => {
         />
         
         {/* ✅ PAGINATION CONTROLS: Untuk mode lazy loading */}
-        {useLazyLoading && paginationInfo.totalPages > 1 && (
+        {paginationInfo.totalPages > 1 && (
           <div className="flex items-center justify-between mt-6 p-4 bg-white rounded-lg border">
             <div className="text-sm text-gray-600">
-              Halaman {currentPage} dari {paginationInfo.totalPages} 
+              Halaman {currentPage} dari {paginationInfo.totalPages}
               ({paginationInfo.totalCount} total pesanan)
             </div>
             <div className="flex items-center gap-2">

--- a/src/components/purchase/PurchasePage.tsx
+++ b/src/components/purchase/PurchasePage.tsx
@@ -146,7 +146,7 @@ const PurchasePageContent: React.FC<PurchasePageProps> = ({ className = '' }) =>
   // ✅ NEW: State untuk lazy loading dan paginasi
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [useLazyLoading, setUseLazyLoading] = useState(false);
+  const [useLazyLoading] = useState(true);
   const [paginationInfo, setPaginationInfo] = useState({ total: 0, totalPages: 0 });
 
   // ✅ NEW: Fungsi untuk mengambil data purchase dengan paginasi
@@ -193,19 +193,19 @@ const PurchasePageContent: React.FC<PurchasePageProps> = ({ className = '' }) =>
   } = useQuery({
     queryKey: ['purchases', 'paginated', user?.id, currentPage, itemsPerPage],
     queryFn: () => fetchPurchasesPaginated(user!.id, currentPage, itemsPerPage),
-    enabled: useLazyLoading && !!user?.id,
+    enabled: !!user?.id,
     staleTime: 30000,
   });
 
   // ✅ NEW: Update pagination info ketika data berubah
   useEffect(() => {
-    if (paginatedData && useLazyLoading) {
+    if (paginatedData) {
       setPaginationInfo({
         total: paginatedData.total,
         totalPages: paginatedData.totalPages
       });
     }
-  }, [paginatedData, useLazyLoading]);
+  }, [paginatedData]);
 
   // ✅ pakai API dari context langsung
   const {
@@ -403,51 +403,29 @@ const PurchasePageContent: React.FC<PurchasePageProps> = ({ className = '' }) =>
       {/* Data warning banner */}
 
 
-      {/* ✅ NEW: Kontrol Lazy Loading */}
+      {/* Kontrol Paginasi */}
       <div className="mb-6 p-4 bg-gray-50 rounded-lg border">
         <div className="flex flex-wrap items-center gap-4">
           <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              id="useLazyLoading"
-              checked={useLazyLoading}
+            <label className="text-sm text-gray-600">Item per halaman:</label>
+            <select
+              value={itemsPerPage}
               onChange={(e) => {
-                setUseLazyLoading(e.target.checked);
-                if (e.target.checked) {
-                  setCurrentPage(1);
-                }
+                setItemsPerPage(Number(e.target.value));
+                setCurrentPage(1);
               }}
-              className="rounded border-gray-300 text-orange-600 focus:ring-orange-500"
-            />
-            <label htmlFor="useLazyLoading" className="text-sm font-medium text-gray-700">
-              Aktifkan Lazy Loading
-            </label>
+              className="border border-gray-300 rounded px-2 py-1 text-sm"
+            >
+              <option value={5}>5</option>
+              <option value={10}>10</option>
+              <option value={20}>20</option>
+              <option value={50}>50</option>
+            </select>
           </div>
 
-          {useLazyLoading && (
-            <>
-              <div className="flex items-center gap-2">
-                <label className="text-sm text-gray-600">Item per halaman:</label>
-                <select
-                  value={itemsPerPage}
-                  onChange={(e) => {
-                    setItemsPerPage(Number(e.target.value));
-                    setCurrentPage(1);
-                  }}
-                  className="border border-gray-300 rounded px-2 py-1 text-sm"
-                >
-                  <option value={5}>5</option>
-                  <option value={10}>10</option>
-                  <option value={20}>20</option>
-                  <option value={50}>50</option>
-                </select>
-              </div>
-
-              <div className="text-sm text-gray-600">
-                Total: {paginationInfo.total} pembelian
-              </div>
-            </>
-          )}
+          <div className="text-sm text-gray-600">
+            Total: {paginationInfo.total} pembelian
+          </div>
         </div>
       </div>
 
@@ -496,8 +474,8 @@ const PurchasePageContent: React.FC<PurchasePageProps> = ({ className = '' }) =>
             </Suspense>
           </PurchaseTableProvider>
 
-          {/* ✅ NEW: Kontrol Paginasi untuk Lazy Loading */}
-          {useLazyLoading && paginationInfo.totalPages > 1 && (
+          {/* Kontrol Paginasi */}
+          {paginationInfo.totalPages > 1 && (
             <div className="mt-6 flex items-center justify-between">
               <div className="text-sm text-gray-600">
                 Halaman {currentPage} dari {paginationInfo.totalPages}

--- a/src/components/supplier/SupplierManagement.tsx
+++ b/src/components/supplier/SupplierManagement.tsx
@@ -91,20 +91,20 @@ const SupplierManagement: React.FC = () => {
   // 🎯 NEW: Lazy loading state
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [useLazyLoading, setUseLazyLoading] = useState(false);
+  const [useLazyLoading] = useState(true);
 
   // 🎯 NEW: Paginated query for lazy loading
   const paginatedQuery = useQuery({
     queryKey: [...supplierQueryKeys.list(), 'paginated', currentPage, itemsPerPage],
     queryFn: () => fetchSuppliersPaginated(user!.id, currentPage, itemsPerPage),
-    enabled: useLazyLoading && !!user?.id,
+    enabled: !!user?.id,
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
   // Use paginated data when lazy loading is enabled, otherwise use regular data
-  const displaySuppliers = useLazyLoading ? (paginatedQuery.data?.data || []) : suppliers;
-  const displayLoading = useLazyLoading ? paginatedQuery.isLoading : isLoading;
-  const paginationInfo = useLazyLoading ? paginatedQuery.data : null;
+  const displaySuppliers = paginatedQuery.data?.data || [];
+  const displayLoading = paginatedQuery.isLoading;
+  const paginationInfo = paginatedQuery.data;
 
   const {
     searchTerm,
@@ -123,11 +123,11 @@ const SupplierManagement: React.FC = () => {
   } = useSupplierTable(displaySuppliers);
   
   // Override pagination controls when lazy loading is enabled
-  const finalItemsPerPage = useLazyLoading ? itemsPerPage : tableItemsPerPage;
-  const finalCurrentPage = useLazyLoading ? currentPage : tablePage;
-  const finalTotalPages = useLazyLoading ? (paginationInfo?.totalPages || 1) : totalPages;
-  const finalCurrentSuppliers = useLazyLoading ? displaySuppliers : currentSuppliers;
-  const finalFilteredSuppliers = useLazyLoading ? displaySuppliers : filteredSuppliers;
+  const finalItemsPerPage = itemsPerPage;
+  const finalCurrentPage = currentPage;
+  const finalTotalPages = paginationInfo?.totalPages || 1;
+  const finalCurrentSuppliers = displaySuppliers;
+  const finalFilteredSuppliers = displaySuppliers;
 
   const handleEdit = (supplier: Supplier) => {
     setEditingSupplier(supplier);
@@ -205,51 +205,31 @@ const SupplierManagement: React.FC = () => {
 
       {/* Main Table Card */}
       <div className="bg-white rounded-xl border border-gray-200/80 overflow-hidden">
-        {/* Lazy Loading Controls */}
+        {/* Kontrol Paginasi */}
         <div className="p-4 border-b border-gray-200 bg-gray-50">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
             <div className="flex items-center gap-4">
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={useLazyLoading}
+              <div className="flex items-center gap-2 text-sm">
+                <label htmlFor="itemsPerPage">Items per page:</label>
+                <select
+                  id="itemsPerPage"
+                  value={itemsPerPage}
                   onChange={(e) => {
-                    setUseLazyLoading(e.target.checked);
-                    setCurrentPage(1); // Reset ke halaman 1 saat toggle
+                    setItemsPerPage(Number(e.target.value));
+                    setCurrentPage(1);
                   }}
-                  className="rounded border-gray-300 text-orange-600 focus:ring-orange-500"
-                />
-                <span className="font-medium">Lazy Loading</span>
-                {useLazyLoading && (
-                  <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full">
-                    Server-side
-                  </span>
-                )}
-              </label>
-              
-              {useLazyLoading && (
-                <div className="flex items-center gap-2 text-sm">
-                  <label htmlFor="itemsPerPage">Items per page:</label>
-                  <select
-                    id="itemsPerPage"
-                    value={itemsPerPage}
-                    onChange={(e) => {
-                      setItemsPerPage(Number(e.target.value));
-                      setCurrentPage(1);
-                    }}
-                    className="border border-gray-300 rounded px-2 py-1 text-sm"
-                  >
-                    <option value={5}>5</option>
-                    <option value={10}>10</option>
-                    <option value={25}>25</option>
-                    <option value={50}>50</option>
-                  </select>
-                </div>
-              )}
+                  className="border border-gray-300 rounded px-2 py-1 text-sm"
+                >
+                  <option value={5}>5</option>
+                  <option value={10}>10</option>
+                  <option value={25}>25</option>
+                  <option value={50}>50</option>
+                </select>
+              </div>
             </div>
-            
+
             <div className="text-sm text-gray-600">
-              {useLazyLoading && paginationInfo && (
+              {paginationInfo && (
                 <span className="text-blue-600 font-medium">
                   Total: {paginationInfo.total} supplier
                 </span>
@@ -263,21 +243,12 @@ const SupplierManagement: React.FC = () => {
           searchTerm={searchTerm}
           onSearchChange={(term) => {
             setSearchTerm(term);
-            if (useLazyLoading) {
-              setCurrentPage(1);
-            } else {
-              setTablePage(1);
-            }
+            setCurrentPage(1);
           }}
           itemsPerPage={finalItemsPerPage}
           onItemsPerPageChange={(count) => {
-            if (useLazyLoading) {
-              setItemsPerPage(count);
-              setCurrentPage(1);
-            } else {
-              setTableItemsPerPage(count);
-              setTablePage(1);
-            }
+            setItemsPerPage(count);
+            setCurrentPage(1);
           }}
           isSelectionMode={isSelectionMode}
           onSelectionModeChange={setIsSelectionMode}
@@ -296,7 +267,7 @@ const SupplierManagement: React.FC = () => {
           currentPage={finalCurrentPage}
           totalPages={finalTotalPages}
           itemsPerPage={finalItemsPerPage}
-          onPageChange={useLazyLoading ? setCurrentPage : setTablePage}
+          onPageChange={setCurrentPage}
           onAddFirst={openAddDialog}
           searchTerm={searchTerm}
         />

--- a/src/components/update/UpdatesPage.tsx
+++ b/src/components/update/UpdatesPage.tsx
@@ -15,7 +15,7 @@ export const UpdatesPage: React.FC = () => {
   // Lazy loading state
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [useLazyLoading, setUseLazyLoading] = useState(false);
+  const [useLazyLoading] = useState(true);
   const [paginationInfo, setPaginationInfo] = useState<{
     total: number;
     totalPages: number;
@@ -23,23 +23,6 @@ export const UpdatesPage: React.FC = () => {
     hasMore: boolean;
   } | null>(null);
 
-  const fetchAllUpdates = async () => {
-    setLoading(true);
-    try {
-      const { data, error } = await supabase
-        .from('app_updates')
-        .select('id, version, title, description, release_date, is_active, priority, created_by, created_at, updated_at')
-        .eq('is_active', true)
-        .order('release_date', { ascending: false });
-
-      if (error) throw error;
-      setUpdates(data || []);
-    } catch (error) {
-      console.error('Error fetching updates:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const fetchUpdatesPaginated = async (page: number, limit: number) => {
     setLoading(true);
@@ -81,12 +64,8 @@ export const UpdatesPage: React.FC = () => {
   };
 
   useEffect(() => {
-    if (useLazyLoading) {
-      loadPaginatedData();
-    } else {
-      fetchAllUpdates();
-    }
-  }, [useLazyLoading, currentPage, itemsPerPage]);
+    loadPaginatedData();
+  }, [currentPage, itemsPerPage]);
 
   const loadPaginatedData = async () => {
     try {
@@ -104,21 +83,13 @@ export const UpdatesPage: React.FC = () => {
   };
 
   const handleRefresh = async () => {
-    if (useLazyLoading) {
-      await loadPaginatedData();
-    } else {
-      await fetchAllUpdates();
-    }
+    await loadPaginatedData();
     await refreshUpdates();
   };
 
   const handleMarkAllAsSeen = async () => {
     await markAllAsSeen();
-    if (useLazyLoading) {
-      await loadPaginatedData();
-    } else {
-      await fetchAllUpdates();
-    }
+    await loadPaginatedData();
   };
 
   // Filter updates based on selected filters and unread status
@@ -177,51 +148,31 @@ export const UpdatesPage: React.FC = () => {
             </div>
           </div>
 
-          {/* Lazy Loading Controls */}
+          {/* Kontrol Paginasi */}
           <div className="mb-4 p-4 bg-gray-50 rounded-lg border border-gray-200">
             <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
               <div className="flex items-center gap-4">
-                <label className="flex items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={useLazyLoading}
+                <div className="flex items-center gap-2 text-sm">
+                  <label htmlFor="itemsPerPage">Items per page:</label>
+                  <select
+                    id="itemsPerPage"
+                    value={itemsPerPage}
                     onChange={(e) => {
-                      setUseLazyLoading(e.target.checked);
+                      setItemsPerPage(Number(e.target.value));
                       setCurrentPage(1);
                     }}
-                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  <span className="font-medium">Lazy Loading</span>
-                  {useLazyLoading && (
-                    <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full">
-                      Server-side
-                    </span>
-                  )}
-                </label>
-                
-                {useLazyLoading && (
-                  <div className="flex items-center gap-2 text-sm">
-                    <label htmlFor="itemsPerPage">Items per page:</label>
-                    <select
-                      id="itemsPerPage"
-                      value={itemsPerPage}
-                      onChange={(e) => {
-                        setItemsPerPage(Number(e.target.value));
-                        setCurrentPage(1);
-                      }}
-                      className="border border-gray-300 rounded px-2 py-1 text-sm"
-                    >
-                      <option value={5}>5</option>
-                      <option value={10}>10</option>
-                      <option value={25}>25</option>
-                      <option value={50}>50</option>
-                    </select>
-                  </div>
-                )}
+                    className="border border-gray-300 rounded px-2 py-1 text-sm"
+                  >
+                    <option value={5}>5</option>
+                    <option value={10}>10</option>
+                    <option value={25}>25</option>
+                    <option value={50}>50</option>
+                  </select>
+                </div>
               </div>
-              
+
               <div className="text-sm text-gray-600">
-                {useLazyLoading && paginationInfo && (
+                {paginationInfo && (
                   <span className="text-blue-600 font-medium">
                     Total: {paginationInfo.total} update
                   </span>
@@ -289,8 +240,8 @@ export const UpdatesPage: React.FC = () => {
           </div>
         )}
         
-        {/* Pagination Controls for Lazy Loading */}
-        {useLazyLoading && paginationInfo && paginationInfo.totalPages > 1 && (
+        {/* Pagination Controls */}
+        {paginationInfo && paginationInfo.totalPages > 1 && (
           <div className="mt-8 flex items-center justify-between">
             <div className="text-sm text-gray-600">
               Halaman {paginationInfo.currentPage} dari {paginationInfo.totalPages}

--- a/src/components/warehouse/WarehousePage.tsx
+++ b/src/components/warehouse/WarehousePage.tsx
@@ -405,7 +405,7 @@ const WarehousePageContent: React.FC = () => {
   // 🎯 NEW: Lazy loading state
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [useLazyLoading, setUseLazyLoading] = useState(false);
+  const [useLazyLoading] = useState(true);
 
   // ✅ TAMBAH: Use warehouse data hook with pagination support
   const warehouseData = useWarehouseData(currentPage, itemsPerPage, useLazyLoading);
@@ -621,52 +621,32 @@ const WarehousePageContent: React.FC = () => {
             isPagePartiallySelected={core.selection?.isPagePartiallySelected}
           />
 
-          {/* Lazy Loading Controls */}
+          {/* Kontrol Paginasi */}
           <div className="p-4 border-t border-gray-200 bg-gray-50">
             <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
               <div className="flex items-center gap-4">
-                <label className="flex items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={useLazyLoading}
+                <div className="flex items-center gap-2 text-sm">
+                  <label htmlFor="itemsPerPage">Items per page:</label>
+                  <select
+                    id="itemsPerPage"
+                    value={itemsPerPage}
                     onChange={(e) => {
-                      setUseLazyLoading(e.target.checked);
-                      setCurrentPage(1); // Reset ke halaman 1 saat toggle
+                      setItemsPerPage(Number(e.target.value));
+                      setCurrentPage(1);
                     }}
-                    className="rounded border-gray-300 text-orange-600 focus:ring-orange-500"
-                  />
-                  <span className="font-medium">Lazy Loading</span>
-                  {useLazyLoading && (
-                    <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full">
-                      Server-side
-                    </span>
-                  )}
-                </label>
-                
-                {useLazyLoading && (
-                  <div className="flex items-center gap-2 text-sm">
-                    <label htmlFor="itemsPerPage">Items per page:</label>
-                    <select
-                      id="itemsPerPage"
-                      value={itemsPerPage}
-                      onChange={(e) => {
-                        setItemsPerPage(Number(e.target.value));
-                        setCurrentPage(1);
-                      }}
-                      className="border border-gray-300 rounded px-2 py-1 text-sm"
-                    >
-                      <option value={5}>5</option>
-                      <option value={10}>10</option>
-                      <option value={25}>25</option>
-                      <option value={50}>50</option>
-                    </select>
-                  </div>
-                )}
+                    className="border border-gray-300 rounded px-2 py-1 text-sm"
+                  >
+                    <option value={5}>5</option>
+                    <option value={10}>10</option>
+                    <option value={25}>25</option>
+                    <option value={50}>50</option>
+                  </select>
+                </div>
               </div>
-              
+
               <div className="text-sm text-gray-600">
                 Terakhir diperbarui: {warehouseData.lastUpdated ? new Date(warehouseData.lastUpdated).toLocaleString('id-ID') : 'Tidak diketahui'}
-                {useLazyLoading && warehouseData.paginationInfo && (
+                {warehouseData.paginationInfo && (
                   <span className="ml-2 text-blue-600 font-medium">
                     (Total: {warehouseData.paginationInfo.total} data)
                   </span>
@@ -676,66 +656,33 @@ const WarehousePageContent: React.FC = () => {
           </div>
 
           {/* Pagination */}
-          {useLazyLoading ? (
-            // Server-side pagination
-            warehouseData.paginationInfo && warehouseData.paginationInfo.totalPages > 1 && (
-              <div className="p-4 border-t border-gray-200">
-                <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-                  <div className="text-sm text-gray-600">
-                    Menampilkan {((currentPage - 1) * itemsPerPage) + 1}-{Math.min(currentPage * itemsPerPage, warehouseData.paginationInfo.total)} dari {warehouseData.paginationInfo.total} item
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
-                      disabled={currentPage === 1}
-                      className="px-3 py-1 text-sm border rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors"
-                    >
-                      Sebelumnya
-                    </button>
-                    <span className="px-3 py-1 text-sm font-medium">
-                      Halaman {currentPage} dari {warehouseData.paginationInfo.totalPages}
-                    </span>
-                    <button
-                      onClick={() => setCurrentPage(prev => Math.min(warehouseData.paginationInfo!.totalPages, prev + 1))}
-                      disabled={currentPage === warehouseData.paginationInfo.totalPages}
-                      className="px-3 py-1 text-sm border rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors"
-                    >
-                      Selanjutnya
-                    </button>
-                  </div>
+          {warehouseData.paginationInfo && warehouseData.paginationInfo.totalPages > 1 && (
+            <div className="p-4 border-t border-gray-200">
+              <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+                <div className="text-sm text-gray-600">
+                  Menampilkan {((currentPage - 1) * itemsPerPage) + 1}-{Math.min(currentPage * itemsPerPage, warehouseData.paginationInfo.total)} dari {warehouseData.paginationInfo.total} item
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
+                    disabled={currentPage === 1}
+                    className="px-3 py-1 text-sm border rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors"
+                  >
+                    Sebelumnya
+                  </button>
+                  <span className="px-3 py-1 text-sm font-medium">
+                    Halaman {currentPage} dari {warehouseData.paginationInfo.totalPages}
+                  </span>
+                  <button
+                    onClick={() => setCurrentPage(prev => Math.min(warehouseData.paginationInfo!.totalPages, prev + 1))}
+                    disabled={currentPage === warehouseData.paginationInfo.totalPages}
+                    className="px-3 py-1 text-sm border rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors"
+                  >
+                    Selanjutnya
+                  </button>
                 </div>
               </div>
-            )
-          ) : (
-            // Client-side pagination
-            (core.filters?.filteredItems?.length || 0) > 0 && (
-              <div className="p-4 border-t border-gray-200">
-                <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-                  <div className="text-sm text-gray-600">
-                    Menampilkan {(core.pagination?.startIndex || 0) + 1}-{Math.min(core.pagination?.endIndex || 0, core.filters?.filteredItems?.length || 0)} dari {core.filters?.filteredItems?.length || 0} item
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={() => core.pagination?.setPage?.((core.pagination?.page || 1) - 1)}
-                      disabled={(core.pagination?.page || 1) === 1}
-                      className="px-3 py-1 text-sm border rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors"
-                    >
-                      Sebelumnya
-                    </button>
-                    <span className="px-3 py-1 text-sm font-medium">
-                      Halaman {core.pagination?.page || 1} dari {core.pagination?.totalPages || 1}
-                    </span>
-                    <button
-                      onClick={() => core.pagination?.setPage?.((core.pagination?.page || 1) + 1)}
-                      disabled={(core.pagination?.page || 1) === (core.pagination?.totalPages || 1)}
-                      className="px-3 py-1 text-sm border rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors"
-                    >
-                      Selanjutnya
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Ringkasan
- sembunyikan opsi toggling lazy loading di halaman pembelian, perangkat, gudang, pemasok, pembaruan aplikasi, transaksi finansial, dan pesanan
- aktifkan lazy loading sebagai perilaku bawaan pada seluruh modul tersebut

## Pengujian
- `npm test` *(gagal: Missing script: "test")*
- `npm run lint` *(gagal: Unexpected any, require import, dll)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0835c400832eb197ae82d3b26c1d