### PR TITLE
feat: multi-axis line chart for profit analysis

### DIFF
--- a/src/components/profitAnalysis/components/charts/ChartRenderers.tsx
+++ b/src/components/profitAnalysis/components/charts/ChartRenderers.tsx
@@ -48,11 +48,16 @@ export const LineChartRenderer: React.FC<BaseChartProps> = ({
     stockValue: { ...metricConfigs.stockValue, color: enhancedColors.stockValue }
   };
 
+  const activeMetrics = selectedMetrics.filter(metric => !hiddenMetrics.has(metric));
+  const showLeftAxis = activeMetrics.some(metric => enhancedMetricConfigs[metric]?.axis !== 'right');
+  const showRightAxis = activeMetrics.some(metric => enhancedMetricConfigs[metric]?.axis === 'right');
+  const rightAxisIsPercentage = activeMetrics.some(metric => enhancedMetricConfigs[metric]?.axis === 'right' && enhancedMetricConfigs[metric]?.isPercentage);
+
   return (
     <ResponsiveContainer width="100%" height={400}>
       <LineChart 
         data={trendData} 
-        margin={{ top: 30, right: 40, left: 20, bottom: 20 }}
+        margin={{ top: 30, right: 60, left: 20, bottom: 20 }}
       >
         {/* Enhanced grid with subtle styling */}
         <CartesianGrid 
@@ -77,18 +82,36 @@ export const LineChartRenderer: React.FC<BaseChartProps> = ({
           dy={10}
         />
         
-        {/* Enhanced Y-axis */}
-        <YAxis 
-          tick={{ 
-            fontSize: 11, 
-            fill: '#6b7280',
-            fontWeight: 500
-          }}
-          tickFormatter={(value) => viewType === 'margins' ? `${value}%` : formatLargeNumber(value)}
-          axisLine={false}
-          tickLine={false}
-          dx={-10}
-        />
+        {showLeftAxis && (
+          <YAxis
+            yAxisId="left"
+            tick={{
+              fontSize: 11,
+              fill: '#6b7280',
+              fontWeight: 500
+            }}
+            tickFormatter={(value) => formatLargeNumber(value)}
+            axisLine={false}
+            tickLine={false}
+            dx={-10}
+          />
+        )}
+
+        {showRightAxis && (
+          <YAxis
+            yAxisId="right"
+            orientation="right"
+            tick={{
+              fontSize: 11,
+              fill: '#6b7280',
+              fontWeight: 500
+            }}
+            tickFormatter={(value) => rightAxisIsPercentage ? `${value}%` : formatLargeNumber(value)}
+            axisLine={false}
+            tickLine={false}
+            dx={10}
+          />
+        )}
         
         {/* Enhanced tooltip */}
         <Tooltip 
@@ -168,16 +191,16 @@ export const LineChartRenderer: React.FC<BaseChartProps> = ({
               strokeWidth={isHighlighted ? 4 : 3}
               strokeOpacity={baseOpacity}
               strokeDasharray={lineStyle.strokeDasharray}
-              dot={{ 
-                fill: config.color, 
+              dot={{
+                fill: config.color,
                 stroke: '#ffffff',
-                strokeWidth: 2, 
+                strokeWidth: 2,
                 r: isHighlighted ? 6 : 4,
                 fillOpacity: baseOpacity
               }}
-              activeDot={{ 
-                r: 8, 
-                stroke: config.color, 
+              activeDot={{
+                r: 8,
+                stroke: config.color,
                 strokeWidth: 3,
                 fill: '#ffffff',
                 fillOpacity: 1,
@@ -187,9 +210,10 @@ export const LineChartRenderer: React.FC<BaseChartProps> = ({
               }}
               name={config.label}
               connectNulls={false}
+              yAxisId={config.axis === 'right' ? 'right' : 'left'}
             />
-          );
-        }).filter(Boolean)}
+         );
+       }).filter(Boolean)}
       </LineChart>
     </ResponsiveContainer>
   );

--- a/src/components/profitAnalysis/components/charts/hooks.ts
+++ b/src/components/profitAnalysis/components/charts/hooks.ts
@@ -90,14 +90,14 @@ export function useProfitTrendChart({
 
   // Metric configurations
   const metricConfigs = useMemo(() => ({
-    revenue: { key: 'revenue', label: 'Omset', color: CHART_CONFIG.colors.revenue },
-    grossProfit: { key: 'grossProfit', label: 'Untung Kotor', color: CHART_CONFIG.colors.primary },
-    netProfit: { key: 'netProfit', label: 'Untung Bersih', color: '#dc2626' },
-    cogs: { key: 'cogs', label: 'Modal Bahan', color: CHART_CONFIG.colors.cogs },
-    opex: { key: 'opex', label: 'Biaya Tetap', color: CHART_CONFIG.colors.opex },
-    grossMargin: { key: 'grossMargin', label: 'Margin Kotor', color: CHART_CONFIG.colors.primary },
-    netMargin: { key: 'netMargin', label: 'Margin Bersih', color: '#dc2626' },
-    stockValue: { key: 'stockValue', label: 'Nilai Stok (WAC)', color: CHART_CONFIG.colors.warning }
+    revenue: { key: 'revenue', label: 'Omset', color: CHART_CONFIG.colors.revenue, axis: 'left' },
+    grossProfit: { key: 'grossProfit', label: 'Untung Kotor', color: CHART_CONFIG.colors.primary, axis: 'right' },
+    netProfit: { key: 'netProfit', label: 'Untung Bersih', color: '#dc2626', axis: 'right' },
+    cogs: { key: 'cogs', label: 'Modal Bahan', color: CHART_CONFIG.colors.cogs, axis: 'left' },
+    opex: { key: 'opex', label: 'Biaya Tetap', color: CHART_CONFIG.colors.opex, axis: 'left' },
+    grossMargin: { key: 'grossMargin', label: 'Margin Kotor', color: CHART_CONFIG.colors.primary, axis: 'right', isPercentage: true },
+    netMargin: { key: 'netMargin', label: 'Margin Bersih', color: '#dc2626', axis: 'right', isPercentage: true },
+    stockValue: { key: 'stockValue', label: 'Nilai Stok (WAC)', color: CHART_CONFIG.colors.warning, axis: 'left' }
   }), []);
 
   // Auto-update selectedMetrics when viewType changes

--- a/src/components/profitAnalysis/components/charts/types.ts
+++ b/src/components/profitAnalysis/components/charts/types.ts
@@ -38,6 +38,8 @@ export interface MetricConfig {
   key: string;
   label: string;
   color: string;
+  axis?: 'left' | 'right';
+  isPercentage?: boolean;
 }
 
 export interface MetricConfigs {


### PR DESCRIPTION
## Summary
- dukung sumbu ganda pada grafik tren profit
- konfigurasi metrik memuat info sumbu dan persentase
- tipe metrik diperluas agar mendukung axis

## Testing
- `npm run lint` *(gagal: Unexpected any & require issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2b016260832e82a47797f50e5cdf