### PR TITLE
feat: multi-axis line chart for profit analysis

### DIFF
--- a/src/components/profitAnalysis/components/charts/InteractiveComponents.tsx
+++ b/src/components/profitAnalysis/components/charts/InteractiveComponents.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { TrendingUp, BarChart3 } from 'lucide-react';
-import { InteractiveLegendProps, ChartControlsProps } from './types';
+import { InteractiveLegendProps, ChartControlsProps, MetricConfigs } from './types';
 
 // ==============================================
 // INTERACTIVE LEGEND COMPONENT
@@ -183,7 +183,7 @@ export const ChartControls: React.FC<ChartControlsProps> = ({
 
 export interface MetricTogglesProps {
   viewType: 'values' | 'margins';
-  metricConfigs: any;
+  metricConfigs: MetricConfigs;
   selectedMetrics: string[];
   onToggleMetric: (metric: string) => void;
   isMobile: boolean;
@@ -196,8 +196,8 @@ export const MetricToggles: React.FC<MetricTogglesProps> = ({
   onToggleMetric,
   isMobile
 }) => {
-  const metrics = viewType === 'values' 
-    ? ['revenue', 'grossProfit', 'netProfit', 'cogs', 'opex', 'stockValue'] 
+  const metrics = viewType === 'values'
+    ? ['revenue', 'grossProfit', 'netProfit', 'cogs', 'opex', 'stockValue', 'grossMargin', 'netMargin']
     : ['grossMargin', 'netMargin'];
 
   return (

--- a/src/components/profitAnalysis/components/charts/Tooltips.tsx
+++ b/src/components/profitAnalysis/components/charts/Tooltips.tsx
@@ -29,24 +29,24 @@ export const CustomTooltip: React.FC<TooltipProps> = ({ active, payload, label, 
         <p className="font-bold text-gray-900 text-base">{String(label)}</p>
       </div>
       <div className="space-y-2">
-        {payload && payload.length > 0 && payload.map((entry: any, index: number) => {
+        {payload?.map((entry, index) => {
           if (!entry || entry.value === undefined) return null;
-          
+
           const dataKey = entry.dataKey as keyof typeof metricLabelMap;
           const label = metricLabelMap[dataKey] || entry.dataKey;
           const value = entry.value !== undefined ? entry.value : 0;
-          
+
           return (
             <div key={index} className="flex items-center justify-between space-x-3 py-1">
               <div className="flex items-center space-x-2">
-                <div 
-                  className="w-3 h-3 rounded-full shadow-sm" 
+                <div
+                  className="w-3 h-3 rounded-full shadow-sm"
                   style={{ backgroundColor: entry.color || '#000000' }}
                 />
                 <span className="text-sm font-medium text-gray-700">{label}</span>
               </div>
               <span className="text-sm font-bold text-gray-900 min-w-0">
-                {viewType === 'margins' && (dataKey === 'grossMargin' || dataKey === 'netMargin') 
+                {viewType === 'margins' && (dataKey === 'grossMargin' || dataKey === 'netMargin')
                   ? `${Number(value).toFixed(1)}%`
                   : formatCurrency(Number(value))
                 }

--- a/src/components/profitAnalysis/components/charts/types.ts
+++ b/src/components/profitAnalysis/components/charts/types.ts
@@ -2,6 +2,7 @@
 
 import { RealTimeProfitCalculation } from '../../types/profitAnalysis.types';
 import { ForecastResult, StatisticalAnalysis, AnomalyDetectionResult } from '../../utils/advancedAnalytics';
+import type { TooltipProps as RechartsTooltipProps } from 'recharts';
 
 // ==============================================
 // CHART COMPONENT TYPES
@@ -38,6 +39,8 @@ export interface MetricConfig {
   key: string;
   label: string;
   color: string;
+  axis?: 'left' | 'right';
+  isPercentage?: boolean;
 }
 
 export interface MetricConfigs {
@@ -128,9 +131,6 @@ export interface TrendAnalysis {
 // CHART RENDERER TYPES
 // ==============================================
 
-export interface TooltipProps {
-  active?: boolean;
-  payload?: any[];
-  label?: string | number;
+export interface TooltipProps extends RechartsTooltipProps<number, string> {
   viewType?: 'values' | 'margins';
 }


### PR DESCRIPTION
## Summary
- aktifkan margin di metrik default sehingga sumbu kanan langsung muncul
- toggle metrik menampilkan margin bersama profit untuk multi-axis
- ganti tipe tooltip ke bawaan Recharts dan hilangkan `any`

## Testing
- `npm run lint` *(gagal: Unexpected any & require issues di berkas lain)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2b016260832e82a47797f50e5cdf