### PR TITLE
fix: update fallback dates to 2025

### DIFF
--- a/public/templates/purchase-import-template.csv
+++ b/public/templates/purchase-import-template.csv
@@ -1,4 +1,4 @@
 supplier;tanggal;nama;kuantitas;satuan;harga
-PT Contoh;2024-01-01;Gula;10;kg;50000
-PT Contoh;2024-01-01;Tepung;5;kg;30000
+PT Contoh;2025-01-01;Gula;10;kg;50000
+PT Contoh;2025-01-01;Tepung;5;kg;30000
 

--- a/src/components/profitAnalysis/constants/profitConstants.ts
+++ b/src/components/profitAnalysis/constants/profitConstants.ts
@@ -46,7 +46,7 @@ export const PROFIT_CONSTANTS = {
   
   // Periode default
   DEFAULT_PERIODS: {
-    CURRENT_MONTH: getCurrentMonth(), // "2024-12"
+    CURRENT_MONTH: getCurrentMonth(), // contoh: "2025-01"
     MONTHS_TO_ANALYZE: 12, // Analisis 12 bulan terakhir
   },
   

--- a/src/components/profitAnalysis/types/profitAnalysis.types.ts
+++ b/src/components/profitAnalysis/types/profitAnalysis.types.ts
@@ -43,7 +43,7 @@ export interface PemakaianBahan {
 export interface ProfitAnalysis {
   id: string;
   user_id: string;
-  period: string; // "2024-01" format (YYYY-MM)
+  period: string; // format "YYYY-MM" (contoh: "2025-01")
   period_type: 'daily' | 'monthly' | 'quarterly' | 'yearly';
   
   // Revenue Data

--- a/src/components/purchase/hooks/usePurchaseImport.ts
+++ b/src/components/purchase/hooks/usePurchaseImport.ts
@@ -113,9 +113,9 @@ export const usePurchaseImport = ({ onImportComplete }: { onImportComplete: () =
   const downloadTemplate = () => {
     const csvContent = [
       'tanggal;supplier;nama;jumlah;satuan;total',
-      '2024-01-15;PT. Maju Jaya;tepung terigu;10;kg;120000',
-      '2024-01-16;CV. Sumber Rejeki;gula pasir;5;kg;75000',
-      '2024-01-17;Toko Bahan Kue;minyak goreng;2;liter;40000'
+      '2025-01-15;PT. Maju Jaya;tepung terigu;10;kg;120000',
+      '2025-01-16;CV. Sumber Rejeki;gula pasir;5;kg;75000',
+      '2025-01-17;Toko Bahan Kue;minyak goreng;2;liter;40000'
     ].join('\n');
 
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });

--- a/src/components/warehouse/hooks/useImportExport.ts
+++ b/src/components/warehouse/hooks/useImportExport.ts
@@ -191,7 +191,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
           kategori: FNB_COGS_CATEGORIES[0],
           supplier: 'PT Supplier Terpercaya',
           satuan: 'gram',
-          expiry: '2024-12-31',
+          expiry: '2025-12-31',
           stok: 5000,
           minimum: 1000
         },
@@ -200,7 +200,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
           kategori: FNB_COGS_CATEGORIES[1],
           supplier: 'CV Gula Manis',
           satuan: 'gram',
-          expiry: '2024-11-30',
+          expiry: '2025-11-30',
           stok: 3000,
           minimum: 500
         },
@@ -254,7 +254,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
           kategori: FNB_COGS_CATEGORIES[0],
           supplier: 'PT Supplier Terpercaya',
           satuan: 'gram',
-          expiry: '2024-12-31',
+          expiry: '2025-12-31',
           stok: 5000,
           minimum: 1000
         },
@@ -263,7 +263,7 @@ export const useImportExport = ({ onImport }: UseImportExportProps) => {
           kategori: FNB_COGS_CATEGORIES[1],
           supplier: 'CV Gula Manis',
           satuan: 'gram',
-          expiry: '2024-11-30',
+          expiry: '2025-11-30',
           stok: 3000,
           minimum: 500
         },

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -50,11 +50,11 @@ const getDefaultDateRange = () => {
       };
     }
     // Ultimate fallback
-     const fallbackFrom = safeParseDate('2024-01-01');
-     const fallbackTo = safeParseDate('2024-12-31');
+     const fallbackFrom = safeParseDate('2025-01-01');
+     const fallbackTo = safeParseDate('2025-12-31');
      return {
-       from: normalizeDateForDatabase(fallbackFrom || new Date('2024-01-01')),
-       to: normalizeDateForDatabase(fallbackTo || new Date('2024-12-31'))
+       from: normalizeDateForDatabase(fallbackFrom || new Date('2025-01-01')),
+       to: normalizeDateForDatabase(fallbackTo || new Date('2025-12-31'))
      };
   }
 };

--- a/src/utils/unifiedDateUtils.ts
+++ b/src/utils/unifiedDateUtils.ts
@@ -289,7 +289,7 @@ export const getDateRangePreset = (key: string): { from: Date, to: Date } => {
   
   if (!isValidDate(today)) {
     console.error('System date is invalid!');
-    const fallbackDate = new Date('2024-01-01');
+    const fallbackDate = new Date('2025-01-01');
     return { from: fallbackDate, to: fallbackDate };
   }
   


### PR DESCRIPTION
## Summary
- ganti tanggal fallback ke tahun 2025
- perbarui komentar dan template agar konsisten dengan 2025

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 990 problems)


------
https://chatgpt.com/codex/tasks/task_e_68ac3dcddc00832e8a511cec9c32097e