### PR TITLE
bypass validasi biaya bulanan saat argumen kosong

### DIFF
--- a/src/components/operational-costs/__tests__/dualModeSystem.test.ts
+++ b/src/components/operational-costs/__tests__/dualModeSystem.test.ts
@@ -134,7 +134,7 @@ describe('Dual-Mode Cost Calculations', () => {
       );
       
       expect(result.isValid).toBe(false);
-      expect(result.validationErrors).toContain('Target produksi harus lebih dari 0');
+      expect(result.validationErrors).toContain('Target produksi harus lebih dari 0 pcs');
       expect(result.costPerUnit).toBe(0);
     });
     
@@ -281,7 +281,7 @@ describe('Validation System', () => {
     it('should reject zero or negative values', () => {
       const zeroResult = validateTargetOutput(0);
       expect(zeroResult.isValid).toBe(false);
-      expect(zeroResult.errors[0]).toContain('Target produksi harus lebih dari 0');
+      expect(zeroResult.errors[0]).toContain('Target produksi tidak boleh 0 pcs');
       
       const negativeResult = validateTargetOutput(-100);
       expect(negativeResult.isValid).toBe(false);
@@ -302,7 +302,7 @@ describe('Validation System', () => {
     it('should reject amounts below minimum', () => {
       const result = validateMonthlyAmount(500);
       expect(result.isValid).toBe(false);
-      expect(result.errors[0]).toContain('minimal Rp 1.000');
+      expect(result.errors[0]).toContain('minimal 1.000');
     });
   });
   

--- a/src/components/operational-costs/components/CostFormDialog.tsx
+++ b/src/components/operational-costs/components/CostFormDialog.tsx
@@ -104,7 +104,7 @@ export const CostFormDialog: React.FC<CostFormDialogProps> = ({
     if (formData.jumlah_per_bulan <= 0) {
       newErrors.jumlah_per_bulan = 'Jumlah harus lebih dari 0';
     } else if (formData.jumlah_per_bulan < 1000) {
-      newErrors.jumlah_per_bulan = 'Jumlah biaya terlalu kecil. Minimal Rp 1.000 untuk pencatatan yang akurat';
+      newErrors.jumlah_per_bulan = 'Jumlah biaya terlalu kecil. Minimal 1.000 untuk pencatatan yang akurat';
     }
 
     if (formData.jumlah_per_bulan > 999999999) {

--- a/src/components/operational-costs/components/DualModeCalculator.tsx
+++ b/src/components/operational-costs/components/DualModeCalculator.tsx
@@ -102,7 +102,7 @@ const DualModeCalculator: React.FC<DualModeCalculatorProps> = ({
     
     try {
       // Validate inputs
-      const validation = validateDualModeInputs(targetOutput, 0, 'Calculator');
+      const validation = validateDualModeInputs(targetOutput, undefined, 'Calculator');
       if (!validation.isValid) {
         toast.error('Input tidak valid', {
           description: validation.errors.join(', ')

--- a/src/components/operational-costs/services/appSettingsApi.ts
+++ b/src/components/operational-costs/services/appSettingsApi.ts
@@ -260,7 +260,7 @@ export const appSettingsApi = {
       if (targetOutput <= 0) {
         return {
           data: {} as AppSettings,
-          error: 'Target produksi harus lebih dari 0'
+          error: 'Target produksi harus lebih dari 0 pcs'
         };
       }
 

--- a/src/components/operational-costs/utils/costValidation.ts
+++ b/src/components/operational-costs/utils/costValidation.ts
@@ -24,9 +24,9 @@ export const validateCostForm = (data: CostFormData): ValidationResult => {
     errors.nama_biaya = 'Nama biaya maksimal 255 karakter';
   }
 
-  // Validate jumlah_per_bulan (minimum Rp 1.000)
+  // Validate jumlah_per_bulan (minimum 1.000)
   if (!data.jumlah_per_bulan || data.jumlah_per_bulan < 1000) {
-    errors.jumlah_per_bulan = 'Jumlah biaya terlalu kecil. Minimal Rp 1.000 untuk pencatatan yang akurat';
+    errors.jumlah_per_bulan = 'Jumlah biaya terlalu kecil. Minimal 1.000 untuk pencatatan yang akurat';
   } else if (data.jumlah_per_bulan > 999999999999) {
     errors.jumlah_per_bulan = 'Jumlah biaya terlalu besar';
   } else if (data.jumlah_per_bulan > 100000000) {

--- a/src/components/operational-costs/utils/dualModeCalculations.ts
+++ b/src/components/operational-costs/utils/dualModeCalculations.ts
@@ -31,11 +31,11 @@ export const calculateCostPerUnit = (
   const validationErrors: string[] = [];
   
   if (targetOutputMonthly <= 0) {
-    validationErrors.push('Target produksi harus lebih dari 0');
+    validationErrors.push('Target produksi harus lebih dari 0 pcs');
   }
   
   if (totalCosts < 1000) {
-    validationErrors.push('Total biaya harus minimal Rp 1.000');
+    validationErrors.push('Total biaya harus minimal 1.000');
   }
   
   // Calculate cost per unit
@@ -167,7 +167,7 @@ export const calculateSellingPrice = (
  */
 export const validateDualModeInputs = (
   targetOutput: number,
-  monthlyAmount: number,
+  monthlyAmount?: number | null,
   costName: string
 ): { isValid: boolean; errors: string[] } => {
   const errors: string[] = [];
@@ -177,9 +177,11 @@ export const validateDualModeInputs = (
     errors.push('Target produksi harus lebih dari 0 pcs');
   }
   
-  // Monthly amount validation  
-  if (!monthlyAmount || monthlyAmount < 1000) {
-    errors.push('Jumlah biaya terlalu kecil. Minimal Rp 1.000 untuk pencatatan yang akurat');
+  // Monthly amount validation
+  if (monthlyAmount != null) {
+    if (!monthlyAmount || monthlyAmount < 1000) {
+      errors.push('Jumlah biaya terlalu kecil. Minimal 1.000 untuk pencatatan yang akurat');
+    }
   }
   
   // Cost name validation

--- a/src/components/operational-costs/utils/validationAndMicrocopy.ts
+++ b/src/components/operational-costs/utils/validationAndMicrocopy.ts
@@ -111,16 +111,16 @@ export const MICROCOPY = {
     // Specific validation messages
     TARGET_OUTPUT_TOO_LOW: 'Target produksi terlalu rendah. Untuk bisnis UMKM, minimal 100 pcs per bulan disarankan.',
     TARGET_OUTPUT_TOO_HIGH: 'Target produksi sangat tinggi. Pastikan angka sudah benar.',
-    AMOUNT_TOO_LOW: 'Jumlah biaya terlalu kecil. Minimal Rp 1.000 untuk pencatatan yang akurat.',
-    AMOUNT_TOO_HIGH: 'Jumlah biaya sangat besar. Pastikan angka sudah benar.',
-    COST_NAME_EMPTY: 'Nama biaya tidak boleh kosong',
-    COST_NAME_TOO_SHORT: 'Nama biaya terlalu pendek. Minimal 3 karakter untuk kejelasan.',
-    
-    // Calculation specific
-    DIVISION_BY_ZERO: 'Target produksi tidak boleh 0. Masukkan jumlah produk yang akan dibuat per bulan.',
-    NEGATIVE_RESULT: 'Hasil kalkulasi tidak boleh negatif. Periksa kembali input Anda.',
-    PERCENTAGE_TOO_HIGH: 'Persentase terlalu tinggi. Maksimal 1000% untuk keamanan kalkulasi.'
-  },
+    AMOUNT_TOO_LOW: 'Jumlah biaya terlalu kecil. Minimal 1.000 untuk pencatatan yang akurat.',
+      AMOUNT_TOO_HIGH: 'Jumlah biaya sangat besar. Pastikan angka sudah benar.',
+      COST_NAME_EMPTY: 'Nama biaya tidak boleh kosong',
+      COST_NAME_TOO_SHORT: 'Nama biaya terlalu pendek. Minimal 3 karakter untuk kejelasan.',
+
+      // Calculation specific
+      DIVISION_BY_ZERO: 'Target produksi tidak boleh 0 pcs. Masukkan jumlah produk yang akan dibuat per bulan.',
+      NEGATIVE_RESULT: 'Hasil kalkulasi tidak boleh negatif. Periksa kembali input Anda.',
+      PERCENTAGE_TOO_HIGH: 'Persentase terlalu tinggi. Maksimal 1000% untuk keamanan kalkulasi.'
+    },
   
   // Success messages
   SUCCESS: {


### PR DESCRIPTION
## Ringkasan
- Lewati pengecekan `monthlyAmount` ketika parameter tidak diberikan atau bernilai null
- Perbarui `DualModeCalculator` agar memanggil validasi tanpa nilai biaya bulanan
- Selaraskan pesan validasi target produksi menggunakan satuan pcs
- Hapus awalan "Rp" dari pesan validasi minimum biaya untuk konsistensi

## Pengujian
- `npm test` (gagal: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68ad51b366b0832e829d34092049f888