### PR TITLE
Perbaikan pembacaan jumlah_per_bulan pada biaya operasional

### DIFF
--- a/src/components/profitAnalysis/services/profitAnalysisApi.ts
+++ b/src/components/profitAnalysis/services/profitAnalysisApi.ts
@@ -501,7 +501,7 @@ const parseOpExCosts = (costsJson: any): any[] => {
       
       return {
         nama_biaya: friendlyName,
-        jumlah_per_bulan: Number(c.amount) || 0,
+        jumlah_per_bulan: Number(c.jumlah_per_bulan ?? c.amount) || 0,
         jenis: c.type || 'tetap',
         cost_category: c.category || 'general'
       };


### PR DESCRIPTION
## Ringkasan
- perbarui `parseOpExCosts` untuk membaca nilai `jumlah_per_bulan` atau `amount` sehingga biaya operasional tidak lagi selalu nol

## Pengujian
- `npm test` ❌ gagal: Missing script "test"
- `npm run lint` ❌ gagal: 992 problems (880 errors, 112 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68ad59ef4150832e96607287138f6a43