### PR TITLE
Perbaiki jarak ikon tooltip pada StatsGrid

### DIFF
--- a/src/components/dashboard/StatsGrid.tsx
+++ b/src/components/dashboard/StatsGrid.tsx
@@ -237,7 +237,7 @@ const StatCard: React.FC<{
 
           {/* 🏷️ Label - Full width */}
           <div className="mb-2 sm:mb-3">
-            <div className="flex items-start gap-1">
+            <div className="flex items-start gap-2">
               <div className="card-label-responsive uppercase tracking-wide font-medium leading-relaxed break-words line-clamp-2">
                 {shortLabel || label}
               </div>


### PR DESCRIPTION
## Ringkasan
- longgarkan jarak antara label dan ikon tooltip di kartu statistik dashboard

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `npm run lint` (gagal: 992 problems)

------
https://chatgpt.com/codex/tasks/task_e_68ad9a6d6a34832e8b64ab03e250e3a8