### PR TITLE
Perbaiki responsivitas header laporan & pembelian

### DIFF
--- a/src/components/financial/FinancialReportPage.tsx
+++ b/src/components/financial/FinancialReportPage.tsx
@@ -457,7 +457,7 @@ const FinancialReportPage: React.FC = () => {
               </div>
             </div>
 
-            <div className="hidden md:flex items-center gap-3">
+            <div className="hidden md:flex flex-wrap items-center gap-3">
               <Button
                 onClick={() => openTransactionDialog()}
                 disabled={isLoading}
@@ -475,7 +475,7 @@ const FinancialReportPage: React.FC = () => {
                 {isMobile ? "Kategori" : "Kelola Kategori"}
               </Button>
 
-              <div className="min-w-[260px]">
+              <div className="w-full md:w-auto md:min-w-[260px]">
                 <DateRangePicker
                   dateRange={dateRangeForPicker}
                   onDateRangeChange={handleDateRangeChange}

--- a/src/components/purchase/components/PurchaseHeader.tsx
+++ b/src/components/purchase/components/PurchaseHeader.tsx
@@ -41,20 +41,20 @@ const PurchaseHeader: React.FC<PurchaseHeaderProps> = ({
           </div>
           
           {/* Right actions */}
-          <div className="flex flex-col sm:flex-row gap-3 w-full lg:w-auto">
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3 w-full lg:w-auto">
             {/* Import button */}
             <Button
               onClick={() => onAddPurchase('import')}
-              className="flex items-center justify-center gap-2 px-6 py-3 bg-white text-orange-600 font-semibold rounded-lg border hover:bg-gray-100 transition-colors duration-200"
+              className="w-full sm:w-auto flex items-center justify-center gap-2 px-6 py-3 bg-white text-orange-600 font-semibold rounded-lg border hover:bg-gray-100 transition-colors duration-200"
             >
               <Upload className="h-5 w-5" />
               Import Data
             </Button>
-            
+
             {/* Tambah dari Nota */}
             <Button
               onClick={() => onAddPurchase('packaging')} // Pastikan tipe 'packaging' sesuai dengan yang diharapkan
-              className="flex items-center justify-center gap-2 px-6 py-3 bg-white text-orange-600 font-semibold rounded-lg border hover:bg-gray-100 transition-colors duration-200"
+              className="w-full sm:w-auto flex items-center justify-center gap-2 px-6 py-3 bg-white text-orange-600 font-semibold rounded-lg border hover:bg-gray-100 transition-colors duration-200"
             >
               <FileText className="h-5 w-5" />
               Tambah Pembelian


### PR DESCRIPTION
## Ringkasan
- Atur ulang aksi header laporan keuangan agar membungkus dan kalender lebar adaptif
- Perbarui header pembelian agar tombol bisa memenuhi lebar dan membungkus di layar kecil

## Pengujian
- `npm test` (gagal: Missing script)
- `npm run lint` (gagal: Unexpected any dan error lain)


------
https://chatgpt.com/codex/tasks/task_e_68ad9b501958832e876ddd74065cbb51