### PR TITLE
Perbaiki responsivitas header laporan keuangan dan pembelian

### DIFF
--- a/src/components/financial/FinancialReportPage.tsx
+++ b/src/components/financial/FinancialReportPage.tsx
@@ -444,7 +444,7 @@ const FinancialReportPage: React.FC = () => {
     <AuthGuard>
       <div className="p-4 sm:p-6 space-y-6">
         <div className="bg-gradient-to-r from-orange-500 to-red-500 rounded-xl p-6 text-white border">
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div className="flex flex-col md:flex-row md:flex-wrap md:items-center md:justify-between gap-4">
             <div className="flex items-center gap-4">
               <div className="bg-white bg-opacity-20 p-3 rounded-xl backdrop-blur-sm">
                 <TrendingUp className="h-8 w-8 text-white" />
@@ -481,7 +481,7 @@ const FinancialReportPage: React.FC = () => {
                   onDateRangeChange={handleDateRangeChange}
                   placeholder="Pilih periode laporan"
                   isMobile={isMobile}
-                  className="bg-white text-gray-900 border-none hover:bg-gray-100"
+                  className="bg-white text-gray-900 border-none hover:bg-gray-100 w-full"
                 />
               </div>
             </div>

--- a/src/components/purchase/components/PurchaseHeader.tsx
+++ b/src/components/purchase/components/PurchaseHeader.tsx
@@ -41,7 +41,7 @@ const PurchaseHeader: React.FC<PurchaseHeaderProps> = ({
           </div>
           
           {/* Right actions */}
-          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3 w-full lg:w-auto">
+          <div className="flex flex-col sm:flex-row flex-wrap gap-3 w-full lg:w-auto">
             {/* Import button */}
             <Button
               onClick={() => onAddPurchase('import')}


### PR DESCRIPTION
## Ringkasan
- Bungkus aksi header laporan keuangan dengan `md:flex-wrap`
- Sesuaikan `DateRangePicker` agar melebar penuh di layar kecil
- Izinkan tombol header pembelian membungkus baris berikutnya

## Pengujian
- `npm test` (gagal: Missing script: "test")
- `npm run lint` (gagal: Unexpected any, require import, dll)


------
https://chatgpt.com/codex/tasks/task_e_68ad9d407900832ea46837b2ad61ac1b