### PR TITLE
Fix Tooltip controlled/uncontrolled warning

### DIFF
--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -15,29 +15,28 @@ const Tooltip = ({
     typeof window !== "undefined" &&
     window.matchMedia("(pointer: coarse)").matches
 
-  if (isTouchDevice) {
-    return (
-      <TooltipPrimitive.Root open={open} onOpenChange={setOpen} {...props}>
-        {React.Children.map(children, (child) => {
-          if (
-            React.isValidElement(child) &&
-            child.type === TooltipPrimitive.Trigger
-          ) {
-            const originalOnClick = (child.props as { onClick?: React.MouseEventHandler<HTMLElement> }).onClick
-            return React.cloneElement(child, {
-              onClick: (e: React.MouseEvent<HTMLElement>) => {
-                originalOnClick?.(e)
-                setOpen((prev) => !prev)
-              },
-            })
-          }
-          return child
-        })}
-      </TooltipPrimitive.Root>
-    )
-  }
-
-  return <TooltipPrimitive.Root {...props}>{children}</TooltipPrimitive.Root>
+  return (
+    <TooltipPrimitive.Root open={open} onOpenChange={setOpen} {...props}>
+      {React.Children.map(children, (child) => {
+        if (
+          isTouchDevice &&
+          React.isValidElement(child) &&
+          child.type === TooltipPrimitive.Trigger
+        ) {
+          const originalOnClick = (child.props as {
+            onClick?: React.MouseEventHandler<HTMLElement>
+          }).onClick
+          return React.cloneElement(child, {
+            onClick: (e: React.MouseEvent<HTMLElement>) => {
+              originalOnClick?.(e)
+              setOpen((prev) => !prev)
+            },
+          })
+        }
+        return child
+      })}
+    </TooltipPrimitive.Root>
+  )
 }
 
 const TooltipTrigger = TooltipPrimitive.Trigger


### PR DESCRIPTION
## Summary
- make tooltip always controlled and handle touch trigger clicks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any, require import)


------
https://chatgpt.com/codex/tasks/task_e_68ad9f1ccb04832e840546c1a63dc3a5