### PR TITLE
Perbaiki tampilan mobile Biaya Operasional

### DIFF
--- a/src/components/operational-costs/components/CostFormDialog.tsx
+++ b/src/components/operational-costs/components/CostFormDialog.tsx
@@ -168,14 +168,14 @@ export const CostFormDialog: React.FC<CostFormDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md w-[95vw] max-h-[90vh] overflow-y-auto">
+      <DialogContent className="w-full sm:max-w-md max-h-[90vh] overflow-y-auto p-4 sm:p-6">
         <DialogHeader>
           <DialogTitle>
             {cost ? '✏️ Edit Biaya Operasional' : '➕ Tambah Biaya Operasional'}
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6">
           {/* Nama Biaya */}
           <div className="space-y-2">
             <Label htmlFor="nama_biaya" className="text-sm font-medium">

--- a/src/components/operational-costs/components/CostManagementTab.tsx
+++ b/src/components/operational-costs/components/CostManagementTab.tsx
@@ -125,7 +125,7 @@ const CostManagementTab: React.FC<CostManagementTabProps> = ({
                 variant={isSelectionMode ? 'default' : 'outline'}
                 onClick={onToggleSelectionMode}
                 className={`flex-1 sm:flex-none ${isSelectionMode ? 'bg-blue-600 hover:bg-blue-700' : 'border-blue-300 text-blue-600 hover:bg-blue-50'}`}
-                size="sm"
+                size="default"
               >
                 {isSelectionMode ? (
                   <>
@@ -142,7 +142,7 @@ const CostManagementTab: React.FC<CostManagementTabProps> = ({
               <Button
                 onClick={onOpenAddDialog}
                 className="flex-1 sm:flex-none bg-orange-600 hover:bg-orange-700"
-                size="sm"
+                size="default"
               >
                 <Plus className="h-4 w-4 mr-2 flex-shrink-0" />
                 <span className="truncate">Tambah Biaya</span>

--- a/src/components/operational-costs/components/DualModeCalculator.tsx
+++ b/src/components/operational-costs/components/DualModeCalculator.tsx
@@ -319,7 +319,7 @@ const DualModeCalculator: React.FC<DualModeCalculatorProps> = ({
             <Button
               onClick={handleCalculate}
               disabled={isCalculating || targetOutput <= 0}
-              className="bg-orange-600 hover:bg-orange-700"
+              className="w-full bg-orange-600 hover:bg-orange-700"
             >
               {isCalculating ? (
                 <>


### PR DESCRIPTION
## Ringkasan
- Perbesar tombol Mode Pilih dan Tambah Biaya
- Rapikan dialog tambah biaya agar lebih cocok di mobile
- Luruskan tombol Hitung Biaya per Pcs

## Pengujian
- `pnpm lint` (gagal: Unexpected any pada beberapa berkas)
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68adb8994d24832e8179abfa89aaec24