### PR TITLE
feat: perbaiki padding dialog

### DIFF
--- a/src/components/UpgradePopup.tsx
+++ b/src/components/UpgradePopup.tsx
@@ -98,7 +98,7 @@ const UpgradePopup = () => {
 
   return (
     <Dialog open={showUpgradePopup} onOpenChange={setShowUpgradePopup}>
-      <DialogContent className="max-w-md mx-auto">
+      <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-center">
             <Zap className="h-6 w-6 text-yellow-500" />

--- a/src/components/assets/AssetManagement.tsx
+++ b/src/components/assets/AssetManagement.tsx
@@ -209,7 +209,7 @@ export const AssetManagement: React.FC = () => {
                     Tambah Aset
                   </Button>
                 </DialogTrigger>
-                <DialogContent className={`${isMobile ? 'w-[95vw] max-w-sm h-[90vh]' : 'w-[95vw] max-w-md max-h-[90vh]'} mx-auto`}>
+                <DialogContent className={`${isMobile ? 'w-[95vw] max-w-sm h-[90vh]' : 'w-[95vw] max-w-md max-h-[90vh]'}`}>
                   <DialogHeader>
                     <DialogTitle className="text-orange-600">
                       {editingAsset ? 'Edit Aset' : 'Tambah Aset Baru'}

--- a/src/components/operational-costs/components/OnboardingModal.tsx
+++ b/src/components/operational-costs/components/OnboardingModal.tsx
@@ -73,7 +73,7 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({ isOpen, onClose, onSk
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
-      <div className="bg-white rounded-xl max-w-lg w-full mx-12 sm:mx-16 md:mx-auto max-h-[70vh] overflow-y-auto shadow-xl">
+      <div className="bg-white rounded-xl max-w-lg w-full px-12 sm:px-16 max-h-[70vh] overflow-y-auto shadow-xl">
         <div className="p-6">
           <div className="text-center mb-6">
             <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-4 sm:p-6 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-xl mx-6 sm:mx-8 md:mx-auto max-h-[70vh] overflow-auto shadow-xl",
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background py-4 sm:py-6 px-6 sm:px-8 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-xl max-h-[70vh] overflow-auto shadow-xl",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -53,11 +53,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-<<<<<<< HEAD
-          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-xl mx-20 sm:mx-24 md:mx-auto max-h-[85vh] sm:max-h-[80vh] overflow-auto shadow-xl",
-=======
-          "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-4 sm:p-6 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-xl mx-8 sm:mx-12 md:mx-auto max-h-[70vh] overflow-auto shadow-xl",
->>>>>>> baafc029bbe660c4a0a2c36f4549c78ce98a411d
+          "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background py-4 sm:py-6 px-8 sm:px-12 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-xl max-h-[70vh] overflow-auto shadow-xl",
           className
         )}
         {...mergedProps}

--- a/src/components/warehouse/components/DialogManager.tsx
+++ b/src/components/warehouse/components/DialogManager.tsx
@@ -20,7 +20,7 @@ const DialogLoader = () => (
 
 const DialogError = ({ error, retry }: { error: Error; retry: () => void }) => (
   <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-    <div className="bg-white rounded-lg p-6 max-w-md mx-4">
+    <div className="bg-white rounded-lg py-6 px-4 max-w-md">
       <div className="flex items-center gap-3 mb-4">
         <div className="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
           <span className="text-red-600 text-xl">⚠️</span>

--- a/src/index.css
+++ b/src/index.css
@@ -83,19 +83,18 @@
 @layer components {
   /* Universal dialog base - safe for all components */
   .dialog-responsive {
-    @apply mx-12 sm:mx-16 md:mx-auto max-h-[85vh] sm:max-h-[80vh] overflow-auto;
-    padding: 1rem;
+    @apply max-h-[85vh] sm:max-h-[80vh] overflow-auto py-4 px-12 sm:px-16;
   }
   
   /* Global dialog container with better iPad support */
   .dialog-content {
-    @apply mx-4 my-8 max-w-lg w-full;
+    @apply my-8 max-w-lg w-full px-4;
   }
   
   /* Mobile phones (up to 640px) */
   @media (max-width: 640px) {
     .dialog-content {
-      @apply mx-3 my-4 max-w-none;
+      @apply my-4 max-w-none px-3;
     }
     
     .dialog-responsive {
@@ -106,7 +105,7 @@
   /* iPad Portrait & small tablets (641px - 768px) */
   @media (min-width: 641px) and (max-width: 768px) {
     .dialog-content {
-      @apply mx-8 my-8 max-w-xl;
+      @apply my-8 max-w-xl px-8;
     }
     
     .dialog-responsive {
@@ -117,7 +116,7 @@
   /* iPad Landscape & medium tablets (769px - 1024px) */
   @media (min-width: 769px) and (max-width: 1024px) {
     .dialog-content {
-      @apply mx-12 my-8 max-w-2xl;
+      @apply my-8 max-w-2xl px-12;
     }
     
     .dialog-responsive {
@@ -128,7 +127,7 @@
   /* Desktop (1025px+) */
   @media (min-width: 1025px) {
     .dialog-content {
-      @apply mx-auto my-8 max-w-3xl;
+      @apply my-8 max-w-3xl px-0;
     }
     
     .dialog-responsive {
@@ -143,7 +142,7 @@
   
   /* Form dialog with enhanced iPad support */
   .form-dialog {
-    @apply bg-white border border-gray-200 mx-12 sm:mx-16 md:mx-auto rounded-xl shadow-xl;
+    @apply bg-white border border-gray-200 rounded-xl shadow-xl px-12 sm:px-16;
     max-width: 500px;
     width: 100%;
   }
@@ -168,7 +167,7 @@
   
   /* Large form dialogs for complex forms */
   .form-dialog-large {
-    @apply bg-white border border-gray-200 mx-12 sm:mx-16 md:mx-auto rounded-xl shadow-xl;
+    @apply bg-white border border-gray-200 rounded-xl shadow-xl px-12 sm:px-16;
     max-width: 800px;
     width: 100%;
   }

--- a/src/pages/MenuPage.tsx
+++ b/src/pages/MenuPage.tsx
@@ -245,7 +245,7 @@ const MenuPage = () => {
 
       {/* Logout Confirmation Dialog */}
       <AlertDialog open={showLogoutConfirm} onOpenChange={setShowLogoutConfirm}>
-        <AlertDialogContent className="max-w-sm mx-auto">
+        <AlertDialogContent className="max-w-sm">
           <AlertDialogHeader>
             <AlertDialogTitle className="text-lg">Konfirmasi Keluar</AlertDialogTitle>
             <AlertDialogDescription className="text-sm">


### PR DESCRIPTION
## Ringkasan
- hapus margin horizontal pada komponen dialog dan ganti dengan padding agar dialog tetap berada di tengah
- selaraskan modal kustom agar tidak lagi menggunakan margin untuk perataan
- sesuaikan utilitas CSS dialog agar memakai padding sebagai pengaman tepi

## Pengujian
- `npm test` (gagal karena tidak ada skrip test)
- `npm run lint` (gagal: 882 errors, 113 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc4ac6150832ea679616478b058f5