### PR TITLE
Perbaiki wrapper PurchasePage agar konten terpusat

### DIFF
--- a/src/components/purchase/PurchasePage.tsx
+++ b/src/components/purchase/PurchasePage.tsx
@@ -268,7 +268,7 @@ const PurchasePageContent: React.FC<PurchasePageProps> = ({ className = '' }) =>
   // ✅ EARLY RETURNS: Optimized error and loading states
   if (finalError) {
     return (
-      <div className={`container mx-auto p-4 sm:p-8 ${className}`}>
+      <div className={`max-w-screen-xl mx-auto p-4 sm:p-8 ${className}`}>
         <div className="text-center py-12">
           <div className="max-w-md mx-auto">
             <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
@@ -292,14 +292,14 @@ const PurchasePageContent: React.FC<PurchasePageProps> = ({ className = '' }) =>
 
   if (finalIsLoading) {
     return (
-      <div className={`container mx-auto p-4 sm:p-8 ${className}`}>
+      <div className={`max-w-screen-xl mx-auto p-4 sm:p-8 ${className}`}>
         <LoadingState />
       </div>
     );
   }
 
   return (
-    <div className={`container mx-auto p-4 sm:p-8 ${className}`}>
+    <div className={`max-w-screen-xl mx-auto p-4 sm:p-8 ${className}`}>
       
       {/* Data warning banner */}
 


### PR DESCRIPTION
## Ringkasan
- Ganti semua wrapper `container` menjadi `max-w-screen-xl` di `PurchasePage`
- Pastikan tampilan error dan loading menggunakan kelas baru

## Pengujian
- `npm test` *(gagal: Missing script "test")*
- `npm run lint` *(gagal: 995 problems)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68adce91b0cc832ebba74143ae952705