### PR TITLE
Perbaiki panel DialogContent untuk mode overlay

### DIFF
--- a/src/components/financial/components/DebtTracker.tsx
+++ b/src/components/financial/components/DebtTracker.tsx
@@ -194,8 +194,7 @@ const DebtTracker: React.FC<DebtTrackerProps> = ({ className }) => {
                 Tambah
               </Button>
             </DialogTrigger>
-            <DialogContent className="dialog-overlay-center">
-              <div className="dialog-panel">
+            <DialogContent centerMode="overlay" size="md">
                 <DialogHeader className="dialog-header-pad">
                   <DialogTitle>Tambah Hutang/Piutang Baru</DialogTitle>
                 </DialogHeader>
@@ -261,12 +260,11 @@ const DebtTracker: React.FC<DebtTrackerProps> = ({ className }) => {
                   
                   </div>
                   
-                  <DialogFooter className="dialog-footer-pad pt-4">
+                <DialogFooter className="dialog-footer-pad pt-4">
                     <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)}>Batal</Button>
                     <Button type="submit">Simpan</Button>
                   </DialogFooter>
                 </form>
-              </div>
             </DialogContent>
           </Dialog>
         </div>

--- a/src/components/operational-costs/dialogs/BulkEditDialog.tsx
+++ b/src/components/operational-costs/dialogs/BulkEditDialog.tsx
@@ -57,15 +57,14 @@ const BulkEditDialog: React.FC<BulkEditDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="dialog-overlay-center">
-        <div className="dialog-panel w-full max-w-md">
+      <DialogContent centerMode="overlay" size="md">
           <DialogHeader className="dialog-header">
             <DialogTitle className="flex items-center gap-2">
               <Settings className="h-5 w-5 text-blue-600" />
               Edit Massal Biaya Operasional
             </DialogTitle>
           </DialogHeader>
-          
+
           <div className="dialog-body space-y-4">
           <div className="bg-gray-50 p-4 rounded-lg">
             <h4 className="font-medium mb-2">Ringkasan biaya yang akan diedit:</h4>
@@ -183,7 +182,6 @@ const BulkEditDialog: React.FC<BulkEditDialogProps> = ({
               Edit {selectedCount} Biaya
             </Button>
           </DialogFooter>
-        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/orders/components/dialogs/BulkDeleteDialog.tsx
+++ b/src/components/orders/components/dialogs/BulkDeleteDialog.tsx
@@ -49,8 +49,7 @@ const BulkDeleteDialog: React.FC<BulkDeleteDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="dialog-overlay-center">
-        <div className="dialog-panel w-full max-w-2xl">
+      <DialogContent centerMode="overlay" size="lg">
           <DialogHeader className="dialog-header-pad">
             <DialogTitle className="flex items-center gap-2 text-red-600">
               <AlertTriangle className="h-5 w-5" />
@@ -149,7 +148,6 @@ const BulkDeleteDialog: React.FC<BulkDeleteDialogProps> = ({
               {loading ? 'Menghapus...' : 'Ya, Hapus Semua'}
             </Button>
           </DialogFooter>
-        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/orders/components/dialogs/BulkEditDialog.tsx
+++ b/src/components/orders/components/dialogs/BulkEditDialog.tsx
@@ -76,8 +76,7 @@ const BulkEditDialog: React.FC<BulkEditDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="dialog-overlay-center">
-        <div className="dialog-panel">
+      <DialogContent centerMode="overlay" size="lg">
           <DialogHeader className="dialog-header-pad">
             <DialogTitle className="flex items-center gap-2">
               <Edit className="h-5 w-5" />
@@ -219,7 +218,6 @@ const BulkEditDialog: React.FC<BulkEditDialogProps> = ({
               {loading ? 'Menyimpan...' : 'Update Status'}
             </Button>
           </DialogFooter>
-        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/profitAnalysis/components/ProfitAnalysisOnboarding.tsx
+++ b/src/components/profitAnalysis/components/ProfitAnalysisOnboarding.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Info } from 'lucide-react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 
 interface ProfitAnalysisOnboardingProps {
@@ -8,11 +9,9 @@ interface ProfitAnalysisOnboardingProps {
 }
 
 const ProfitAnalysisOnboarding: React.FC<ProfitAnalysisOnboardingProps> = ({ isOpen, onClose }) => {
-  if (!isOpen) return null;
-
   return (
-    <div className="dialog-overlay-center p-4">
-      <div className="dialog-panel max-w-lg w-full max-h-[90vh] overflow-y-auto">
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent centerMode="overlay" size="md">
         <div className="dialog-body">
           <div className="text-center mb-6">
             <div className="w-16 h-16 bg-orange-100 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -45,8 +44,8 @@ const ProfitAnalysisOnboarding: React.FC<ProfitAnalysisOnboardingProps> = ({ isO
             Mulai Analisis
           </Button>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/components/purchase/components/dialogs/BulkOperationsDialog.tsx
+++ b/src/components/purchase/components/dialogs/BulkOperationsDialog.tsx
@@ -116,8 +116,7 @@ const BulkOperationsDialog: React.FC<BulkOperationsDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && !isLoading && onCancel()}>
-      <DialogContent className="dialog-overlay-center">
-        <div className="dialog-panel">
+      <DialogContent centerMode="overlay" size="lg">
           <DialogHeader className="dialog-header-pad">
             <DialogTitle className="flex items-center gap-3">
               <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
@@ -323,7 +322,6 @@ const BulkOperationsDialog: React.FC<BulkOperationsDialogProps> = ({
               )}
             </Button>
           </DialogFooter>
-        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/recipe/dialogs/DeleteRecipeDialog.tsx
+++ b/src/components/recipe/dialogs/DeleteRecipeDialog.tsx
@@ -55,9 +55,8 @@ const DeleteRecipeDialog: React.FC<DeleteRecipeDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="dialog-overlay-center">
-        <div className="dialog-panel">
-          <DialogHeader className="dialog-header bg-red-50">
+      <DialogContent centerMode="overlay" size="lg">
+        <DialogHeader className="dialog-header bg-red-50">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 bg-red-100 rounded-lg flex items-center justify-center">
                 <AlertTriangle className="w-5 h-5 text-red-600" />
@@ -71,9 +70,9 @@ const DeleteRecipeDialog: React.FC<DeleteRecipeDialogProps> = ({
                 </p>
               </div>
             </div>
-          </DialogHeader>
+        </DialogHeader>
 
-          <div className="dialog-body">
+        <div className="dialog-body">
           
           {/* Warning Message */}
           <div className="mb-6">
@@ -209,10 +208,10 @@ const DeleteRecipeDialog: React.FC<DeleteRecipeDialogProps> = ({
             )}
           </div>
 
-          </div>
+        </div>
 
-          {/* Footer with Action Buttons */}
-          <DialogFooter className="dialog-footer">
+        {/* Footer with Action Buttons */}
+        <DialogFooter className="dialog-footer">
             <Button
               variant="outline"
               onClick={() => onOpenChange(false)}
@@ -238,8 +237,7 @@ const DeleteRecipeDialog: React.FC<DeleteRecipeDialogProps> = ({
                 </>
               )}
             </Button>
-          </DialogFooter>
-        </div>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -77,7 +77,7 @@ const DialogContent = React.forwardRef<
     // Mode translate: direct panel styling (shadcn-compatible)
     translate:
       `fixed left-1/2 top-1/2 z-[75] w-full ${sizeClasses[size]} -translate-x-1/2 -translate-y-1/2 ` +
-      "border bg-background shadow-2xl duration-200 mx-4 rounded-xl " +
+      "border bg-background shadow-2xl duration-200 mx-auto rounded-xl " +
       // Enhanced animations
       "data-[state=open]:animate-in data-[state=closed]:animate-out " +
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 " +
@@ -96,18 +96,51 @@ const DialogContent = React.forwardRef<
         className={cn(baseClassByMode[centerMode], className)}
         {...mergedProps}
       >
-        {children}
-        {!hideCloseButton && (
-          <DialogPrimitive.Close className={cn(
-            "absolute right-4 top-4 z-10 rounded-sm opacity-70 ring-offset-background",
-            "transition-all duration-200 hover:opacity-100 hover:bg-gray-100 dark:hover:bg-gray-800", 
-            "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
-            "disabled:pointer-events-none p-1",
-            centerMode === "overlay" && "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-          )}>
-            <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
+        {centerMode === "overlay" ? (
+          <div
+            className={cn(
+              "relative w-full mx-auto",
+              sizeClasses[size],
+              "border bg-background shadow-2xl duration-200 rounded-xl",
+              "data-[state=open]:animate-in data-[state=closed]:animate-out",
+              "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+              "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+              "max-h-[90dvh] overflow-hidden flex flex-col"
+            )}
+          >
+            {children}
+            {!hideCloseButton && (
+              <DialogPrimitive.Close
+                className={cn(
+                  "absolute right-4 top-4 z-10 rounded-sm opacity-70 ring-offset-background",
+                  "transition-all duration-200 hover:opacity-100 hover:bg-gray-100 dark:hover:bg-gray-800",
+                  "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+                  "disabled:pointer-events-none p-1",
+                  "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                )}
+              >
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+              </DialogPrimitive.Close>
+            )}
+          </div>
+        ) : (
+          <>
+            {children}
+            {!hideCloseButton && (
+              <DialogPrimitive.Close
+                className={cn(
+                  "absolute right-4 top-4 z-10 rounded-sm opacity-70 ring-offset-background",
+                  "transition-all duration-200 hover:opacity-100 hover:bg-gray-100 dark:hover:bg-gray-800",
+                  "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+                  "disabled:pointer-events-none p-1"
+                )}
+              >
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+              </DialogPrimitive.Close>
+            )}
+          </>
         )}
       </DialogPrimitive.Content>
     </DialogPortal>

--- a/src/components/warehouse/dialogs/ImportExportDialog.tsx
+++ b/src/components/warehouse/dialogs/ImportExportDialog.tsx
@@ -26,8 +26,8 @@ const ImportDialog: React.FC<ImportDialogProps> = ({ isOpen, onClose, onImport }
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="dialog-overlay-center">
-        <div className="dialog-panel max-w-5xl flex flex-col h-full">
+      <DialogContent centerMode="overlay" size="full">
+        <div className="w-full max-w-5xl flex flex-col h-full">
           <DialogHeader className="dialog-header-pad">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">


### PR DESCRIPTION
## Ringkasan
- Gunakan `centerMode="overlay"` pada dialog di modul resep, pembelian, pesanan, biaya operasional, gudang, keuangan, dan analisis profit
- Hilangkan wrapper `dialog-panel` sehingga konten memanfaatkan batas lebar internal

## Pengujian
- `npm test` (gagal: Missing script "test")
- `npm run lint` (gagal: Unexpected any & require import)


------
https://chatgpt.com/codex/tasks/task_e_68aeb53a01b4832ea6c4da2a5f24f6b8