### PR TITLE
refactor: sederhanakan panel mobile DateRangePicker

### DIFF
--- a/src/components/ui/DateRangePicker.tsx
+++ b/src/components/ui/DateRangePicker.tsx
@@ -174,34 +174,32 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
         <DialogTrigger asChild>
           <Button {...buttonProps}>{content}</Button>
         </DialogTrigger>
-        <DialogContent centerMode="overlay" size="md">
-          <div className="dialog-panel dialog-panel-md-plus dialog-no-overflow">
-            <DialogHeader className="dialog-header">
-              <DialogTitle className="text-overflow-safe">Pilih Rentang Tanggal</DialogTitle>
-              <DialogDescription className="text-overflow-safe">
-                Pilih rentang tanggal untuk memfilter data.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="dialog-body">
-              <div className="space-y-3">
-                <PresetButtons />
-                <div className="p-3 dialog-no-overflow">
-                  <Calendar
-                    mode="range"
-                    selected={calendarRange}
-                    onSelect={handleCalendarChange}
-                    numberOfMonths={1}
-                    locale={id}
-                    className="mx-auto"
-                  />
-                  <div className="flex flex-col gap-2 mt-4 pt-4 border-t">
-                    <Button variant="outline" onClick={handleReset} className="input-mobile-safe">
-                      <span className="text-overflow-safe">Reset</span>
-                    </Button>
-                    <Button onClick={() => setIsOpen(false)} className="input-mobile-safe">
-                      <span className="text-overflow-safe">Terapkan</span>
-                    </Button>
-                  </div>
+        <DialogContent centerMode="overlay" size="md" className="dialog-no-overflow">
+          <DialogHeader className="dialog-header">
+            <DialogTitle className="text-overflow-safe">Pilih Rentang Tanggal</DialogTitle>
+            <DialogDescription className="text-overflow-safe">
+              Pilih rentang tanggal untuk memfilter data.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="dialog-body">
+            <div className="space-y-3">
+              <PresetButtons />
+              <div className="p-3 dialog-no-overflow">
+                <Calendar
+                  mode="range"
+                  selected={calendarRange}
+                  onSelect={handleCalendarChange}
+                  numberOfMonths={1}
+                  locale={id}
+                  className="mx-auto"
+                />
+                <div className="flex flex-col gap-2 mt-4 pt-4 border-t">
+                  <Button variant="outline" onClick={handleReset} className="input-mobile-safe">
+                    <span className="text-overflow-safe">Reset</span>
+                  </Button>
+                  <Button onClick={() => setIsOpen(false)} className="input-mobile-safe">
+                    <span className="text-overflow-safe">Terapkan</span>
+                  </Button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Ringkasan
- hilangkan wrapper dialog-panel di mode mobile
- pindahkan DialogHeader dan isi langsung di bawah DialogContent dengan class `dialog-no-overflow`

## Pengujian
- `npm run lint src/components/ui/DateRangePicker.tsx` *(gagal: banyak masalah lint di file lain)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb9556644832e8f46b630d831b7c3