### PR TITLE
refactor: gunakan safeDom untuk penghapusan toast

### DIFF
--- a/src/utils/toastSwipeHandler.ts
+++ b/src/utils/toastSwipeHandler.ts
@@ -211,7 +211,7 @@ const showSwipeIndicator = (element: HTMLElement, distance: number) => {
 const hideSwipeIndicator = (element: HTMLElement) => {
   const indicator = element.querySelector('.toast-swipe-indicator');
   if (indicator) {
-    indicator.remove();
+    safeDom.removeElement(indicator);
   }
 };
 
@@ -226,7 +226,7 @@ const dismissToast = (element: HTMLElement) => {
     if (closeButton) {
       closeButton.click();
     } else {
-      element.remove();
+      safeDom.removeElement(element);
     }
   }, 300);
 };


### PR DESCRIPTION
## Ringkasan
- Gunakan `safeDom.removeElement` untuk indikator swipe dan elemen toast.

## Pengujian
- `pnpm lint` (gagal: Unexpected any, require import)


------
https://chatgpt.com/codex/tasks/task_e_68c64288d258832ebb27322163d02e65