### PR TITLE
Gunakan safeDom.removeElement pada pembersihan PDF

### DIFF
--- a/src/components/invoice/utils/invoicePDF.ts
+++ b/src/components/invoice/utils/invoicePDF.ts
@@ -435,13 +435,13 @@ const cleanupElementAfterPDF = async (): Promise<void> => {
     // Remove PDF styles
     const styleElement = document.getElementById('pdf-generation-styles');
     if (styleElement) {
-      styleElement.remove();
+      safeDom.removeElement(styleElement);
     }
     
     // Remove single-page PDF styles
     const singlePageStyleElement = document.getElementById('single-page-pdf-styles');
     if (singlePageStyleElement) {
-      singlePageStyleElement.remove();
+      safeDom.removeElement(singlePageStyleElement);
     }
     
     requestAnimationFrame(resolve);


### PR DESCRIPTION
## Ringkasan
- Ganti pemanggilan `remove()` langsung dengan `safeDom.removeElement` saat membersihkan gaya PDF agar lebih aman.
- Pastikan utilitas `safeDom` sudah diimpor untuk menghindari error DOM.

## Pengujian
- `pnpm lint` *(gagal: 1409 masalah lint yang sudah ada)*
- `pnpm exec eslint src/components/invoice/utils/invoicePDF.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c6428d8bb8832e84b67434b8e7b625