### PR TITLE
Integrasi Turnstile untuk autentikasi OTP

### DIFF
--- a/src/components/auth/TurnstileWidget.tsx
+++ b/src/components/auth/TurnstileWidget.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useRef, useState, forwardRef, useImperativeHandle } from 'react';
+import { TurnstileConfig, TurnstileWidgetRef } from '@/types/turnstile';
+
+interface TurnstileWidgetProps {
+  sitekey: string;
+  onSuccess?: (token: string) => void;
+  onError?: () => void;
+  onExpired?: () => void;
+  theme?: 'light' | 'dark' | 'auto';
+  size?: 'normal' | 'invisible' | 'compact';
+  className?: string;
+}
+
+const TurnstileWidget = forwardRef<TurnstileWidgetRef, TurnstileWidgetProps>(({
+  sitekey,
+  onSuccess,
+  onError,
+  onExpired,
+  theme = 'light',
+  size = 'normal',
+  className = '',
+}, ref) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  const [scriptLoaded, setScriptLoaded] = useState(false);
+
+  useEffect(() => {
+    const loadScript = () => {
+      return new Promise<void>((resolve, reject) => {
+        if (window.turnstile) {
+          setScriptLoaded(true);
+          resolve();
+          return;
+        }
+        const script = document.createElement('script');
+        script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+        script.async = true;
+        script.onload = () => {
+          setScriptLoaded(true);
+          resolve();
+        };
+        script.onerror = () => reject(new Error('Gagal memuat skrip Turnstile'));
+        document.head.appendChild(script);
+      });
+    };
+
+    loadScript().catch((err) => console.error(err));
+  }, []);
+
+  useEffect(() => {
+    if (!scriptLoaded || !containerRef.current || !window.turnstile) return;
+    const config: TurnstileConfig = {
+      sitekey,
+      callback: (token: string) => onSuccess?.(token),
+      'error-callback': onError,
+      'expired-callback': onExpired,
+      theme,
+      size,
+    };
+    widgetIdRef.current = window.turnstile.render(containerRef.current, config);
+  }, [scriptLoaded, sitekey, onSuccess, onError, onExpired, theme, size]);
+
+  useImperativeHandle(ref, () => ({
+    reset() {
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.reset(widgetIdRef.current);
+      }
+    },
+    getResponse() {
+      if (widgetIdRef.current && window.turnstile) {
+        return window.turnstile.getResponse(widgetIdRef.current);
+      }
+      return null;
+    }
+  }));
+
+  return <div ref={containerRef} className={className} />;
+});
+
+TurnstileWidget.displayName = 'TurnstileWidget';
+export default TurnstileWidget;
+export type { TurnstileWidgetProps, TurnstileWidgetRef };

--- a/src/hooks/useTurnstile.ts
+++ b/src/hooks/useTurnstile.ts
@@ -1,0 +1,40 @@
+import { useRef, useState, useCallback } from 'react';
+import { TurnstileWidgetRef, UseTurnstileReturn } from '@/types/turnstile';
+
+export const useTurnstile = (): UseTurnstileReturn => {
+  const widgetRef = useRef<TurnstileWidgetRef | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+
+  const handleSuccess = (t: string) => {
+    setToken(t);
+  };
+
+  const handleError = () => {
+    setToken(null);
+  };
+
+  const handleExpired = () => {
+    setToken(null);
+  };
+
+  const reset = useCallback(() => {
+    widgetRef.current?.reset();
+    setToken(null);
+  }, []);
+
+  const getResponse = () => {
+    return widgetRef.current?.getResponse() || token;
+  };
+
+  return {
+    token,
+    reset,
+    widgetRef,
+    handleSuccess,
+    handleError,
+    handleExpired,
+    getResponse,
+  };
+};
+
+export default useTurnstile;

--- a/src/types/turnstile.ts
+++ b/src/types/turnstile.ts
@@ -1,0 +1,40 @@
+// Types untuk Cloudflare Turnstile
+
+export interface TurnstileConfig {
+  sitekey: string;
+  callback?: (token: string) => void;
+  'error-callback'?: () => void;
+  'expired-callback'?: () => void;
+  theme?: 'light' | 'dark' | 'auto';
+  size?: 'normal' | 'invisible' | 'compact';
+}
+
+export interface Turnstile {
+  render: (container: string | HTMLElement, options?: TurnstileConfig) => string;
+  reset: (widgetId?: string) => void;
+  remove: (widgetId?: string) => void;
+  getResponse: (widgetId?: string) => string;
+}
+
+export interface TurnstileWidgetRef {
+  reset: () => void;
+  getResponse: () => string | null;
+}
+
+export interface UseTurnstileReturn {
+  token: string | null;
+  reset: () => void;
+  widgetRef: React.MutableRefObject<TurnstileWidgetRef | null>;
+  handleSuccess: (token: string) => void;
+  handleError: () => void;
+  handleExpired: () => void;
+  getResponse: () => string | null;
+}
+
+declare global {
+  interface Window {
+    turnstile?: Turnstile;
+  }
+}
+
+export {}; // memastikan file dianggap sebagai modul

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -14,3 +14,12 @@ declare module '*.txt?raw' { const src: string; export default src; }
 declare module '*.svg?raw' { const src: string; export default src; }
 
 declare module '*?url' { const src: string; export default src; }
+
+interface ImportMetaEnv {
+  readonly VITE_TURNSTILE_SITEKEY: string;
+  readonly VITE_TURNSTILE_SECRETKEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Ringkasan
- tambah verifikasi token Turnstile sebelum mengirim OTP
- sediakan komponen dan hook Turnstile untuk halaman login
- definisikan variabel lingkungan `VITE_TURNSTILE_SITEKEY` dan `VITE_TURNSTILE_SECRETKEY`

## Pengujian
- `node node_modules/eslint/bin/eslint.js src/components/auth/TurnstileWidget.tsx src/hooks/useTurnstile.ts src/types/turnstile.ts src/services/auth/core/otp.ts -f json`


------
https://chatgpt.com/codex/tasks/task_e_68c650f23d7c832e8cc73eaeb76356cf