### PR TITLE
Gunakan timestamptz untuk tanggal kadaluwarsa

### DIFF
--- a/src/components/warehouse/services/warehouseApi.ts
+++ b/src/components/warehouse/services/warehouseApi.ts
@@ -29,9 +29,9 @@ const transformToFrontend = (dbItem: any): BahanBakuFrontend => {
     harga: Number(dbItem.harga_satuan) || 0,
     hargaRataRata: wac,
     supplier: dbItem.supplier || '',
-    expiry: dbItem.tanggal_kadaluwarsa || undefined,
-    createdAt: dbItem.created_at,
-    updatedAt: dbItem.updated_at,
+    expiry: dbItem.tanggal_kadaluwarsa ? new Date(dbItem.tanggal_kadaluwarsa) : undefined,
+    createdAt: new Date(dbItem.created_at),
+    updatedAt: new Date(dbItem.updated_at),
   };
 };
 
@@ -47,7 +47,7 @@ const transformToDatabase = (frontendItem: Partial<BahanBakuFrontend>, userId?: 
     harga_satuan: frontendItem.harga,
     harga_rata_rata: frontendItem.hargaRataRata,
     supplier: frontendItem.supplier || '',
-    tanggal_kadaluwarsa: frontendItem.expiry || null,
+    tanggal_kadaluwarsa: frontendItem.expiry ? frontendItem.expiry.toISOString() : null,
   };
   if (userId) dbItem.user_id = userId;
 

--- a/src/components/warehouse/types.ts
+++ b/src/components/warehouse/types.ts
@@ -19,9 +19,9 @@ export interface BahanBaku {
   minimum: number;
   harga_satuan: number;
   supplier: string;
-  tanggal_kadaluwarsa?: Date;
-  created_at: Date;
-  updated_at: Date;
+  tanggal_kadaluwarsa: string | null;
+  created_at: string;
+  updated_at: string;
   harga_rata_rata?: number;            // ✅ TAMBAH: WAC field from DB
 }
 

--- a/src/utils/typeConverters.ts
+++ b/src/utils/typeConverters.ts
@@ -144,9 +144,9 @@ export const convertWarehouseFromDB = (dbBahan: BahanBaku): BahanBakuFrontend =>
     harga: dbBahan.harga_satuan,
     hargaRataRata: dbBahan.harga_rata_rata,
     supplier: dbBahan.supplier,
-    expiry: dbBahan.tanggal_kadaluwarsa,
-    createdAt: dbBahan.created_at,
-    updatedAt: dbBahan.updated_at
+    expiry: dbBahan.tanggal_kadaluwarsa ? new Date(dbBahan.tanggal_kadaluwarsa) : undefined,
+    createdAt: new Date(dbBahan.created_at),
+    updatedAt: new Date(dbBahan.updated_at)
   };
 };
 
@@ -165,9 +165,9 @@ export const convertWarehouseToDB = (bahan: BahanBakuFrontend): BahanBaku => {
     harga_satuan: bahan.harga,
     harga_rata_rata: bahan.hargaRataRata,
     supplier: bahan.supplier,
-    tanggal_kadaluwarsa: bahan.expiry,
-    created_at: bahan.createdAt,
-    updated_at: bahan.updatedAt
+    tanggal_kadaluwarsa: bahan.expiry ? bahan.expiry.toISOString() : null,
+    created_at: bahan.createdAt.toISOString(),
+    updated_at: bahan.updatedAt.toISOString()
   };
 };
 

--- a/supabase/migrations/20251201000000_use_timestamptz_for_bahan_baku_expiry.sql
+++ b/supabase/migrations/20251201000000_use_timestamptz_for_bahan_baku_expiry.sql
@@ -1,0 +1,2 @@
+alter table public.bahan_baku
+  alter column tanggal_kadaluwarsa type timestamptz using tanggal_kadaluwarsa::timestamptz;


### PR DESCRIPTION
## Ringkasan
- gunakan tipe string untuk kolom tanggal di tipe `BahanBaku`
- konversi tanggal ke objek `Date` di service dan utilitas warehouse
- tambahkan migrasi untuk mengubah `tanggal_kadaluwarsa` menjadi `timestamptz`

## Pengujian
- `pnpm lint` (gagal: 1425 masalah, 1268 error, 157 warning)
- `pnpm build` (dihentikan setelah awal proses build)


------
https://chatgpt.com/codex/tasks/task_e_68c6e973bc88832eb06f183380fc5385