### PR TITLE
fix: align purchase fields with database

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ import { Order, NewOrder, OrderItem } from './order';
 import { Asset, AssetCategory, AssetCondition } from './asset';
 import { Activity } from './activity';
 import { FinancialTransaction } from './financial';
+import type { Purchase, PurchaseStatus } from '@/components/purchase/types/purchase.types';
 
 // Ini adalah interface yang sebelumnya ada di AppDataContext
 export interface BahanBaku {
@@ -20,29 +21,6 @@ export interface BahanBaku {
   createdAt: Date | null;
   updatedAt: Date | null;
   userId?: string;
-}
-
-export type PurchaseStatus = 'pending' | 'completed' | 'cancelled';
-
-export interface Purchase {
-  id: string;
-  tanggal: Date;
-  supplier: string;
-  items: {
-    id?: string | number;
-    namaBarang: string;
-    kategori?: string;
-    jumlah: number;
-    satuan?: string;
-    hargaSatuan: number;
-    totalHarga: number;
-  }[];
-  totalNilai: number;
-  status: PurchaseStatus;
-  metodePerhitungan: 'Average';
-  catatan: string | null;
-  createdAt: Date | null;
-  updatedAt: Date | null;
 }
 
 export const PURCHASE_STATUS_CONFIG: Record<
@@ -84,6 +62,17 @@ export interface HPPResult {
 
 // Re-export tipe lain agar bisa diimpor dari satu tempat
 export type {
-    Recipe, RecipeIngredient, Supplier, Order, NewOrder, OrderItem,
-    Asset, AssetCategory, AssetCondition, Activity, FinancialTransaction
+  Recipe,
+  RecipeIngredient,
+  Supplier,
+  Order,
+  NewOrder,
+  OrderItem,
+  Asset,
+  AssetCategory,
+  AssetCondition,
+  Activity,
+  FinancialTransaction,
+  Purchase,
+  PurchaseStatus
 };

--- a/src/utils/financialPurchaseConsistency.ts
+++ b/src/utils/financialPurchaseConsistency.ts
@@ -59,7 +59,10 @@ export function checkFinancialPurchaseConsistency(
       purchase: {
         purchaseCount: purchases.length,
         completedPurchases: purchases.filter(p => p.status === 'completed').length,
-        totalValue: purchases.reduce((sum, p) => sum + Number(p.totalNilai || 0), 0),
+        totalValue: purchases.reduce(
+          (sum, p) => sum + Number((p as any).total_nilai ?? (p as any).totalNilai ?? 0),
+          0
+        ),
         validPurchases: purchases.filter(p => 
           p.supplier && p.tanggal && p.items && p.items.length > 0
         ).length,
@@ -97,7 +100,9 @@ export function checkFinancialPurchaseConsistency(
       );
       
       if (relatedTransaction) {
-        const purchaseValue = Number(purchase.totalNilai || 0);
+        const purchaseValue = Number(
+          (purchase as any).total_nilai ?? (purchase as any).totalNilai ?? 0
+        );
         const transactionAmount = Number(relatedTransaction.amount || 0);
         
         if (Math.abs(purchaseValue - transactionAmount) > 0.01) {

--- a/supabase/functions/hpp-data/index.ts
+++ b/supabase/functions/hpp-data/index.ts
@@ -87,9 +87,9 @@ serve(async (req)=>{
             tanggal: new Date(item.tanggal).toISOString(),
             supplier: item.supplier,
             items: item.items,
-            total_nilai: parseFloat(item.totalNilai) || 0,
+            total_nilai: parseFloat(item.total_nilai ?? item.totalNilai) || 0,
             status: item.status,
-            metode_perhitungan: item.metodePerhitungan,
+            metode_perhitungan: item.metode_perhitungan ?? item.metodePerhitungan,
             catatan: item.catatan
           }));
         const { error: purchasesError } = await supabase.from('purchases').upsert(purchasesData, {


### PR DESCRIPTION
## Summary
- gunakan `total_nilai` sebagai fallback di pemeriksaan konsistensi financial
- perbarui fungsi sync agar menerima `total_nilai` dan `metode_perhitungan`
- ekspor ulang tipe purchase dari modul khusus

## Testing
- `pnpm lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e9586610832ea3ccba7c3c719e0a