### PR TITLE
Wajibkan nomor telepon pada entitas pesanan

### DIFF
--- a/src/components/FollowUpTemplateManager.tsx
+++ b/src/components/FollowUpTemplateManager.tsx
@@ -98,7 +98,7 @@ const FollowUpTemplateManager = ({ isOpen, onClose, order, onSendWhatsApp }) => 
     }
     
     // Open WhatsApp with the message
-    const phoneNumber = order?.teleponPelanggan?.replace(/\D/g, '') || '';
+    const phoneNumber = order?.teleponPelanggan.replace(/\D/g, '') || '';
     
     if (!phoneNumber) {
       toast.error('Nomor telepon pelanggan tidak tersedia');

--- a/src/components/WhatsappFollowUpModal.tsx
+++ b/src/components/WhatsappFollowUpModal.tsx
@@ -15,7 +15,7 @@ interface WhatsappFollowUpModalProps {
     orderNumber: string;
     customerName: string;
     status: string;
-    customerPhone: string | null;
+    customerPhone: string;
     [key: string]: any;
   } | null;
   // ✅ FIXED: Remove dependency on legacy getWhatsappTemplateByStatus
@@ -80,7 +80,7 @@ const WhatsappFollowUpModal: React.FC<WhatsappFollowUpModalProps> = ({
     }
 
     // Start with a clean string, removing all whitespace
-    let number = (order.customerPhone ?? '').replace(/\s+/g, '');
+    let number = order.customerPhone.replace(/\s+/g, '');
 
     // Remove '+' prefix if present
     if (number.startsWith('+')) {

--- a/src/components/orders/context/OrderProvider.tsx
+++ b/src/components/orders/context/OrderProvider.tsx
@@ -437,7 +437,7 @@ export const OrderProvider: React.FC<Props> = ({ children }) => {
     return ordersRef.current.filter(o =>
       o.customerName.toLowerCase().includes(t) ||
       o.orderNumber.toLowerCase().includes(t) ||
-      o.customerPhone?.toLowerCase().includes(t) ||
+      o.customerPhone.toLowerCase().includes(t) ||
       o.customerEmail?.toLowerCase().includes(t)
     );
   }, []);

--- a/src/components/orders/hooks/useOrderUI.ts
+++ b/src/components/orders/hooks/useOrderUI.ts
@@ -32,7 +32,7 @@ export const useOrderUI = (orders: Order[], defaultItemsPerPage: number = 10): U
         const matchesSearch = 
           order.nomorPesanan.toLowerCase().includes(searchTerm) ||
           order.namaPelanggan.toLowerCase().includes(searchTerm) ||
-          (order.teleponPelanggan?.toLowerCase().includes(searchTerm)) ||
+          order.teleponPelanggan.toLowerCase().includes(searchTerm) ||
           (order.emailPelanggan?.toLowerCase().includes(searchTerm));
         
         if (!matchesSearch) return false;

--- a/src/components/orders/types.ts
+++ b/src/components/orders/types.ts
@@ -28,7 +28,7 @@ export interface Order {
   
   // Customer Info
   customerName: string;
-  customerPhone?: string;
+  customerPhone: string;
   customerEmail?: string;
   alamatPengiriman?: string;
   
@@ -57,7 +57,7 @@ export interface Order {
 
 export interface NewOrder {
   customerName: string;
-  customerPhone?: string;
+  customerPhone: string;
   customerEmail?: string;
   alamatPengiriman?: string;
   items: OrderItem[];
@@ -201,7 +201,7 @@ export interface OrderDB {
   updated_at: string;
   tanggal: string;
   nama_pelanggan: string;
-  telepon_pelanggan?: string;
+  telepon_pelanggan: string;
   email_pelanggan?: string;
   alamat_pengiriman?: string;
   items: OrderItem[];

--- a/src/components/orders/utils.ts
+++ b/src/components/orders/utils.ts
@@ -65,7 +65,7 @@ export const transformOrderFromDB = (dbItem: any): Order => {
       id: dbItem.id || 'unknown',
       nomorPesanan: dbItem.nomor_pesanan || generateOrderNumber(),
       namaPelanggan: dbItem.nama_pelanggan || 'Unknown Customer',
-      teleponPelanggan: dbItem.telepon_pelanggan || undefined,
+      teleponPelanggan: dbItem.telepon_pelanggan || '',
       emailPelanggan: dbItem.email_pelanggan || undefined,
       alamatPengiriman: dbItem.alamat_pengiriman || '',
       tanggal: safeParseDate(dbItem.tanggal) || new Date(),
@@ -187,13 +187,14 @@ export const validateOrderData = (data: Partial<NewOrder>): { isValid: boolean; 
   }
   
   // Optional field validations with limits and improved regex
-  if (data.teleponPelanggan && data.teleponPelanggan.length > 0) {
+  if (!data.teleponPelanggan || data.teleponPelanggan.length === 0) {
+    errors.push('Nomor telepon harus diisi');
+  } else {
     const phone = data.teleponPelanggan;
     const phoneLength = phone.length;
     if (phoneLength < VALIDATION_LIMITS.phone.min || phoneLength > VALIDATION_LIMITS.phone.max) {
       errors.push(`Nomor telepon harus antara ${VALIDATION_LIMITS.phone.min} dan ${VALIDATION_LIMITS.phone.max} karakter`);
     } else {
-      // ✅ IMPROVED: Stricter regex for Indonesian phone numbers (local/internasional)
       const phoneRegex = /^(?:\+62|0)[1-9]\d{8,13}$/;
       if (!phoneRegex.test(phone)) {
         errors.push('Format nomor telepon tidak valid (contoh: +628123456789 atau 08123456789)');
@@ -349,7 +350,7 @@ const createFallbackOrder = (id?: string): Order => ({
   id: id || 'error-' + Date.now(),
   nomorPesanan: 'ERROR-' + Date.now().toString().slice(-6),
   namaPelanggan: 'Data Error',
-  teleponPelanggan: undefined,
+  teleponPelanggan: '',
   emailPelanggan: undefined,
   alamatPengiriman: '',
   tanggal: new Date(),
@@ -377,7 +378,7 @@ export const searchOrders = (orders: Order[], searchTerm: string): Order[] => {
   return orders.filter(order => 
     order.namaPelanggan.toLowerCase().includes(lowerSearchTerm) ||
     order.nomorPesanan.toLowerCase().includes(lowerSearchTerm) ||
-    (order.teleponPelanggan?.toLowerCase().includes(lowerSearchTerm)) ||
+    order.teleponPelanggan.toLowerCase().includes(lowerSearchTerm) ||
     (order.emailPelanggan?.toLowerCase().includes(lowerSearchTerm))
   );
 };

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -454,7 +454,7 @@ export const validateOrderItems = (items: any[]): boolean => {
 
 export const validateCustomerInfo = (customer: {
   namaPelanggan?: string;
-  teleponPelanggan?: string;
+  teleponPelanggan: string;
   emailPelanggan?: string;
 }): { isValid: boolean; errors: string[] } => {
   const errors: string[] = [];
@@ -463,7 +463,7 @@ export const validateCustomerInfo = (customer: {
     errors.push('Nama pelanggan wajib diisi');
   }
   
-  if (!customer.teleponPelanggan?.trim()) {
+  if (!customer.teleponPelanggan.trim()) {
     errors.push('Nomor telepon wajib diisi');
   } else if (!isValidPhoneNumber(customer.teleponPelanggan)) {
     errors.push('Format nomor telepon tidak valid');

--- a/src/utils/orderValidation.ts
+++ b/src/utils/orderValidation.ts
@@ -24,7 +24,7 @@ export const ORDER_VALIDATION_RULES = {
     pattern: /^[a-zA-Z\s\u00C0-\u017F\u0100-\u024F\u1E00-\u1EFF\u4e00-\u9faf\u3400-\u4dbf]+$/
   },
   PHONE: {
-    required: false,
+    required: true,
     pattern: /^(\+62|62|0)[0-9]{8,13}$/,
     message: 'Format nomor telepon tidak valid'
   },
@@ -123,8 +123,10 @@ export const validateCustomerInfo = (order: Partial<NewOrder>): OrderValidationR
     }
   }
 
-  // Phone validation (optional)
-  if (order.teleponPelanggan?.trim()) {
+  // Phone validation (required)
+  if (!order.teleponPelanggan || !order.teleponPelanggan.trim()) {
+    errors.push('Nomor telepon tidak boleh kosong');
+  } else {
     const phone = order.teleponPelanggan.trim();
     if (!ORDER_VALIDATION_RULES.PHONE.pattern.test(phone)) {
       errors.push(ORDER_VALIDATION_RULES.PHONE.message);


### PR DESCRIPTION
## Ringkasan
- Jadikan `customerPhone` dan `telepon_pelanggan` sebagai field wajib di seluruh tipe Order
- Perbarui utilitas transformasi, pencarian, dan validasi agar selalu menangani nomor telepon
- Sesuaikan komponen follow-up WhatsApp dengan perubahan field wajib

## Pengujian
- `pnpm run test` (gagal: Missing script: test)
- `pnpm lint` (gagal: 1425 problems)


------
https://chatgpt.com/codex/tasks/task_e_68c6e97d354c832ea1d1117a1dc203de