### PR TITLE
Perbaiki konsistensi total_nilai pada pembelian

### DIFF
--- a/src/components/purchase/__tests__/bulkActionsUtils.test.ts
+++ b/src/components/purchase/__tests__/bulkActionsUtils.test.ts
@@ -17,17 +17,17 @@ describe('Purchase bulk action helpers', () => {
     userId: 'u1',
     supplier: 's1',
     tanggal: new Date('2024-01-01'),
-    totalNilai: 1000,
+    total_nilai: 1000,
     items: [],
     status: 'pending',
-    metodePerhitungan: 'AVERAGE',
+    metode_perhitungan: 'AVERAGE',
     createdAt: new Date('2024-01-01'),
     updatedAt: new Date('2024-01-01'),
   };
 
   const purchases: Purchase[] = [
     { ...basePurchase, id: 'p1' },
-    { ...basePurchase, id: 'p2', totalNilai: 2000 },
+    { ...basePurchase, id: 'p2', total_nilai: 2000 },
   ];
 
   it('dapat mengekspor pembelian ke CSV', () => {

--- a/src/components/purchase/__tests__/dateHandling.test.ts
+++ b/src/components/purchase/__tests__/dateHandling.test.ts
@@ -165,10 +165,10 @@ describe('Date Handling Consistency in Purchase Module', () => {
       const purchaseData = {
         supplier: 'Test Supplier',
         tanggal: new Date('2024-01-15T10:30:00Z'),
-        totalNilai: 100000,
+        total_nilai: 100000,
         items: [],
         status: 'pending' as const,
-        metodePerhitungan: 'AVERAGE' as const
+        metode_perhitungan: 'AVERAGE' as const
       };
 
       const transformed = transformPurchaseForDB(purchaseData, 'user-123');
@@ -190,10 +190,10 @@ describe('Date Handling Consistency in Purchase Module', () => {
         const purchaseData = {
           supplier: 'Test',
           tanggal: input,
-          totalNilai: 100000,
+          total_nilai: 100000,
           items: [],
           status: 'pending' as const,
-          metodePerhitungan: 'AVERAGE' as const
+          metode_perhitungan: 'AVERAGE' as const
         };
 
         const transformed = transformPurchaseForDB(purchaseData, 'user-123');
@@ -221,10 +221,10 @@ describe('Date Handling Consistency in Purchase Module', () => {
         const purchaseData = {
           supplier: 'Test',
           tanggal: invalidDate as any,
-          totalNilai: 100000,
+          total_nilai: 100000,
           items: [],
           status: 'pending' as const,
-          metodePerhitungan: 'AVERAGE' as const
+          metode_perhitungan: 'AVERAGE' as const
         };
 
         const transformed = transformPurchaseForDB(purchaseData, 'user-123');
@@ -363,10 +363,10 @@ describe('Date Handling Consistency in Purchase Module', () => {
         const purchaseData = {
           supplier: 'Test Supplier',
           tanggal: date,
-          totalNilai: 100000,
+          total_nilai: 100000,
           items: [],
           status: 'pending' as const,
-          metodePerhitungan: 'AVERAGE' as const
+          metode_perhitungan: 'AVERAGE' as const
         };
 
         const transformed = transformPurchaseForDB(purchaseData, 'user-123');
@@ -446,10 +446,10 @@ describe('Date Handling Consistency in Purchase Module', () => {
           const purchaseData = {
             supplier: 'Test',
             ...input,
-            totalNilai: 100000,
+            total_nilai: 100000,
             items: [],
             status: 'pending' as const,
-            metodePerhitungan: 'AVERAGE' as const
+            metode_perhitungan: 'AVERAGE' as const
           };
           transformPurchaseForDB(purchaseData, 'user-123');
         }).not.toThrow();
@@ -458,10 +458,10 @@ describe('Date Handling Consistency in Purchase Module', () => {
         const purchaseData = {
           supplier: 'Test',
           ...input,
-          totalNilai: 100000,
+          total_nilai: 100000,
           items: [],
           status: 'pending' as const,
-          metodePerhitungan: 'AVERAGE' as const
+          metode_perhitungan: 'AVERAGE' as const
         };
         
         const result = transformPurchaseForDB(purchaseData, 'user-123');
@@ -550,10 +550,10 @@ describe('Integration Tests', () => {
     const purchaseData = {
       supplier: 'Test Supplier',
       tanggal: parsedDate,
-      totalNilai: 100000,
+      total_nilai: 100000,
       items: [],
       status: 'pending' as const,
-      metodePerhitungan: 'AVERAGE' as const
+      metode_perhitungan: 'AVERAGE' as const
     };
     
     const dbPayload = transformPurchaseForDB(purchaseData, 'user-123');

--- a/src/components/purchase/__tests__/purchaseWarehouseSync.test.ts
+++ b/src/components/purchase/__tests__/purchaseWarehouseSync.test.ts
@@ -150,7 +150,7 @@ describe('Purchase-Warehouse Sync', () => {
       {
         supplier: '',
         tanggal: new Date(),
-        totalNilai: 150000,
+        total_nilai: 150000,
         items: [
           {
             bahanBakuId: 'item1',
@@ -160,7 +160,7 @@ describe('Purchase-Warehouse Sync', () => {
           }
         ],
         status: 'completed',
-        metodePerhitungan: 'AVERAGE'
+        metode_perhitungan: 'AVERAGE'
       },
       userId
     );

--- a/src/components/purchase/components/PurchaseTable.tsx
+++ b/src/components/purchase/components/PurchaseTable.tsx
@@ -157,7 +157,7 @@ const MemoizedPurchaseRow = React.memo(({
       </TableCell>
       <TableCell className="text-right">
         <div className="text-sm font-medium text-gray-900">
-          {formatCurrency(purchase.totalNilai)}
+          {formatCurrency(purchase.total_nilai)}
         </div>
       </TableCell>
       <TableCell>
@@ -600,12 +600,12 @@ const PurchaseTableCore: React.FC<PurchaseTablePropsExtended> = ({
 
                   <TableHead className="text-right">
                     <button
-                      onClick={() => handleSort('totalNilai')}
+                      onClick={() => handleSort('total_nilai')}
                       className="flex items-center h-auto p-0 font-medium hover:bg-transparent"
                     >
                       <Receipt className="h-4 w-4 mr-2" />
                       Total Nilai
-                      {renderSortIcon('totalNilai')}
+                      {renderSortIcon('total_nilai')}
                     </button>
                   </TableHead>
 

--- a/src/components/purchase/components/StatusChangeConfirmationDialog.tsx
+++ b/src/components/purchase/components/StatusChangeConfirmationDialog.tsx
@@ -168,7 +168,7 @@ const StatusChangeConfirmationDialog: React.FC<StatusChangeConfirmationDialogPro
             <div className="text-sm text-gray-600">
               <p><span className="font-medium">Supplier:</span> {purchase.supplier}</p>
               <p><span className="font-medium">Total Items:</span> {purchase.items.length} item</p>
-              <p><span className="font-medium">Total Nilai:</span> Rp {purchase.totalNilai.toLocaleString('id-ID')}</p>
+              <p><span className="font-medium">Total Nilai:</span> Rp {purchase.total_nilai.toLocaleString('id-ID')}</p>
             </div>
 
             {/* Errors */}

--- a/src/components/purchase/components/dialogs/BulkOperationsDialog.tsx
+++ b/src/components/purchase/components/dialogs/BulkOperationsDialog.tsx
@@ -31,7 +31,7 @@ interface BulkOperationsDialogProps {
 interface BulkEditData {
   supplier?: string;
   tanggal?: string; // Date string for input compatibility
-  metodePerhitungan?: 'AVERAGE';
+  metode_perhitungan?: 'AVERAGE';
 }
 
 // Status options for the select dropdown
@@ -61,7 +61,7 @@ const BulkOperationsDialog: React.FC<BulkOperationsDialogProps> = ({
   
   // Internal state for bulk edit data
   const [internalBulkEditData, setInternalBulkEditData] = useState<BulkEditData>({
-    metodePerhitungan: 'AVERAGE'
+    metode_perhitungan: 'AVERAGE'
   });
 
   // Use external data if provided, otherwise use internal state
@@ -71,7 +71,7 @@ const BulkOperationsDialog: React.FC<BulkOperationsDialogProps> = ({
   // Reset form when dialog opens
   useEffect(() => {
     if (isOpen && isEditMode) {
-      const resetData = { metodePerhitungan: 'AVERAGE' as const };
+      const resetData = { metode_perhitungan: 'AVERAGE' as const };
       if (onBulkEditDataChange) {
         onBulkEditDataChange(resetData);
       } else {
@@ -104,7 +104,7 @@ const BulkOperationsDialog: React.FC<BulkOperationsDialogProps> = ({
     return items.reduce(
       (acc, item) => {
         acc.totalItems += item.items?.length || 0;
-        acc.totalAmount += item.totalNilai || 0;
+        acc.totalAmount += item.total_nilai || 0;
         return acc;
       },
       { totalItems: 0, totalAmount: 0 }
@@ -210,8 +210,8 @@ const BulkOperationsDialog: React.FC<BulkOperationsDialogProps> = ({
                       Metode Perhitungan
                     </label>
                     <Select
-                      value={bulkEditData.metodePerhitungan || 'AVERAGE'}
-                      onValueChange={(value) => handleInputChange('metodePerhitungan', value)}
+                      value={bulkEditData.metode_perhitungan || 'AVERAGE'}
+                      onValueChange={(value) => handleInputChange('metode_perhitungan', value)}
                     >
                       <SelectTrigger>
                         <SelectValue />

--- a/src/components/purchase/components/table/PurchaseTableRow.tsx
+++ b/src/components/purchase/components/table/PurchaseTableRow.tsx
@@ -88,7 +88,7 @@ export const PurchaseTableRow: React.FC<PurchaseTableRowProps> = ({
 
       <TableCell className="text-right">
         <div className="font-bold text-green-600">
-          {formatCurrency(purchase.totalNilai)}
+          {formatCurrency(purchase.total_nilai)}
         </div>
       </TableCell>
 

--- a/src/components/purchase/components/table/TableHeader.tsx
+++ b/src/components/purchase/components/table/TableHeader.tsx
@@ -19,7 +19,7 @@ import {
   Receipt,
 } from 'lucide-react';
 
-type SortField = 'tanggal' | 'supplier' | 'totalNilai' | 'status';
+type SortField = 'tanggal' | 'supplier' | 'total_nilai' | 'status';
 type SortOrder = 'asc' | 'desc';
 
 interface TableHeaderProps {
@@ -94,13 +94,13 @@ export const PurchaseTableHeader: React.FC<TableHeaderProps> = ({
         <TableHead className="text-right">
           <Button
             variant="ghost"
-            onClick={() => onSort('totalNilai')}
+            onClick={() => onSort('total_nilai')}
             className="h-auto p-0 font-medium hover:bg-transparent"
             type="button"
           >
             <Receipt className="h-4 w-4 mr-2" />
             Total Nilai
-            {renderSortIcon('totalNilai')}
+            {renderSortIcon('total_nilai')}
           </Button>
         </TableHead>
 

--- a/src/components/purchase/components/table/TableRow.tsx
+++ b/src/components/purchase/components/table/TableRow.tsx
@@ -87,7 +87,7 @@ export const PurchaseTableRow: React.FC<PurchaseTableRowProps> = ({
 
       <TableCell className="text-right">
         <div className="font-bold text-green-600">
-          {formatCurrency(purchase.totalNilai)}
+          {formatCurrency(purchase.total_nilai)}
         </div>
       </TableCell>
 

--- a/src/components/purchase/context/PurchaseContext.tsx
+++ b/src/components/purchase/context/PurchaseContext.tsx
@@ -362,10 +362,10 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         userId: user!.id,
         supplier: payload.supplier,
         tanggal: payload.tanggal,
-        totalNilai: payload.totalNilai,
+        total_nilai: payload.total_nilai,
         items: payload.items,
         status: payload.status ?? 'pending',
-        metodePerhitungan: payload.metodePerhitungan ?? 'AVERAGE',
+        metode_perhitungan: payload.metode_perhitungan ?? 'AVERAGE',
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -507,7 +507,7 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             
             void addFinancialTransaction({
               type: 'expense',
-              amount: fresh.totalNilai,
+              amount: fresh.total_nilai,
               description: `Pembelian dari ${getSupplierName(fresh.supplier)} (auto-sync)`,
               category: 'Pembelian Bahan Baku',
               date: new Date(),
@@ -536,12 +536,12 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           // Tambahkan transaksi ketika status berubah ke completed (expense)
           console.log('💰 Creating financial transaction for completed purchase:', {
             purchaseId: fresh.id,
-            amount: fresh.totalNilai,
+            amount: fresh.total_nilai,
             supplier: getSupplierName(fresh.supplier),
             category: 'Pembelian Bahan Baku',
             transactionData: {
               type: 'expense',
-              amount: fresh.totalNilai,
+              amount: fresh.total_nilai,
               description: `Pembelian dari ${getSupplierName(fresh.supplier)}`,
               category: 'Pembelian Bahan Baku',
               date: new Date(),
@@ -551,7 +551,7 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           
           void addFinancialTransaction({
             type: 'expense',
-            amount: fresh.totalNilai,
+            amount: fresh.total_nilai,
             description: `Pembelian dari ${getSupplierName(fresh.supplier)}`,
             category: 'Pembelian Bahan Baku',
             date: new Date(),
@@ -738,7 +738,7 @@ export const PurchaseProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     if (p.status === newStatus) warnings.push('Status tidak berubah');
     if (newStatus === 'completed') {
       if (!p.items?.length) errors.push('Tidak dapat selesai tanpa item');
-      if (!p.totalNilai || p.totalNilai <= 0) errors.push('Total nilai harus > 0');
+      if (!p.total_nilai || p.total_nilai <= 0) errors.push('Total nilai harus > 0');
       if (!p.supplier) errors.push('Supplier wajib diisi');
       
       // Enhanced item validation for better error reporting

--- a/src/components/purchase/hooks/useBulkOperations.ts
+++ b/src/components/purchase/hooks/useBulkOperations.ts
@@ -19,7 +19,7 @@ interface UseBulkOperationsProps {
 interface BulkEditData {
   supplier?: string;
   tanggal?: Date;
-  metodePerhitungan?: 'AVERAGE';
+  metode_perhitungan?: 'AVERAGE';
 }
 
 interface UseBulkOperationsReturn {
@@ -36,7 +36,7 @@ interface UseBulkOperationsReturn {
 const defaultBulkEditData: BulkEditData = {
   supplier: undefined,
   tanggal: undefined,
-  metodePerhitungan: undefined,
+  metode_perhitungan: undefined,
 };
 
 /**
@@ -121,8 +121,8 @@ export const useBulkOperations = ({
         updates.tanggal = bulkEditData.tanggal;
       }
 
-      if (bulkEditData.metodePerhitungan !== undefined) {
-        updates.metodePerhitungan = bulkEditData.metodePerhitungan;
+      if (bulkEditData.metode_perhitungan !== undefined) {
+        updates.metode_perhitungan = bulkEditData.metode_perhitungan;
       }
 
       logger.debug('📝 Bulk edit updates:', updates);

--- a/src/components/purchase/hooks/usePurchaseImport.ts
+++ b/src/components/purchase/hooks/usePurchaseImport.ts
@@ -378,8 +378,8 @@ export const usePurchaseImport = ({ onImportComplete }: { onImportComplete: () =
                 keterangan: `[IMPORTED] Harga otomatis: Rp ${purchaseData.totalNilai.toLocaleString('id-ID')} ÷ ${item.kuantitas} = Rp ${calculatedUnitPrice.toLocaleString('id-ID')}${bahanBakuId ? ' | Linked to warehouse' : ' | New item'}`
               };
             }),
-            totalNilai: purchaseData.totalNilai,
-            metodePerhitungan: 'AVERAGE' as const,
+            total_nilai: purchaseData.totalNilai,
+            metode_perhitungan: 'AVERAGE' as const,
             status: 'pending' as const // ✅ SAMA: Import and manual both start as pending
           };
 

--- a/src/components/purchase/hooks/usePurchaseStatus.ts
+++ b/src/components/purchase/hooks/usePurchaseStatus.ts
@@ -129,7 +129,7 @@ export const usePurchaseStatus = ({
       if (!purchase.items || purchase.items.length === 0) {
         errors.push('Tidak dapat menyelesaikan purchase tanpa item');
       }
-      if (!purchase.totalNilai || purchase.totalNilai <= 0) {
+      if (!purchase.total_nilai || purchase.total_nilai <= 0) {
         errors.push('Total nilai purchase harus lebih dari 0');
       }
       if (!purchase.supplier) {

--- a/src/components/purchase/tests/supplierNameDisplay.test.ts
+++ b/src/components/purchase/tests/supplierNameDisplay.test.ts
@@ -136,7 +136,7 @@ export const mockPurchaseData = {
   userId: 'user-456',
   supplier: 'sup1', // This should resolve to 'PT. Supplier Utama'
   tanggal: new Date('2024-01-15'),
-  totalNilai: 150000,
+  total_nilai: 150000,
   items: [
     {
       bahanBakuId: 'bb1',
@@ -148,7 +148,7 @@ export const mockPurchaseData = {
     }
   ],
   status: 'completed' as const,
-  metodePerhitungan: 'AVERAGE' as const,
+  metode_perhitungan: 'AVERAGE' as const,
   createdAt: new Date('2024-01-15T08:00:00'),
   updatedAt: new Date('2024-01-15T08:00:00')
 };

--- a/src/components/purchase/utils/purchaseImport.ts
+++ b/src/components/purchase/utils/purchaseImport.ts
@@ -62,9 +62,9 @@ export async function parsePurchaseCSV(file: File): Promise<ImportedPurchase[]> 
         supplier: r.supplier,
         tanggal: new Date(r.tanggal),
         items: [],
-        totalNilai: 0,
+        total_nilai: 0,
         status: 'pending',
-        metodePerhitungan: 'AVERAGE',
+        metode_perhitungan: 'AVERAGE',
       };
       grouped.set(key, purchase);
     }
@@ -78,7 +78,7 @@ export async function parsePurchaseCSV(file: File): Promise<ImportedPurchase[]> 
       subtotal: r.kuantitas * r.harga,
     };
     purchase.items.push(item);
-    purchase.totalNilai += item.subtotal;
+    purchase.total_nilai += item.subtotal;
   });
 
   return Array.from(grouped.values());

--- a/src/components/purchase/utils/validation/formValidation.ts
+++ b/src/components/purchase/utils/validation/formValidation.ts
@@ -34,7 +34,7 @@ export const validatePurchaseForm = (data: Partial<PurchaseFormData>): Validatio
   warnings.push(...itemsValidation.warnings);
 
   // Calculation method validation
-  const methodValidation = validateCalculationMethod(data.metodePerhitungan);
+  const methodValidation = validateCalculationMethod(data.metode_perhitungan);
   if (!methodValidation.isValid && methodValidation.error) {
     errors.push(methodValidation.error);
   }

--- a/src/utils/dateRangeFilteringTest.ts
+++ b/src/utils/dateRangeFilteringTest.ts
@@ -137,7 +137,7 @@ export const testDateRangeFilteringConsistency = async (userId: string) => {
         count: purchaseResults.data?.length || 0,
         data: purchaseResults.data?.slice(0, 3).map(p => ({
           supplier: p.supplier,
-          total: p.totalNilai,
+          total: p.total_nilai,
           tanggal: p.tanggal,
           created_at: p.createdAt
         })) || []

--- a/src/utils/debugPriceCalculation.ts
+++ b/src/utils/debugPriceCalculation.ts
@@ -60,7 +60,7 @@ export const debugPriceCalculation = async () => {
       const items = Array.isArray(purchase.items) ? purchase.items : [];
       console.log(`   ${index + 1}. Purchase ${purchase.id}:`, {
         status: purchase.status,
-        totalNilai: purchase.total_nilai,
+        total_nilai: purchase.total_nilai,
         itemCount: items.length,
         tanggal: purchase.tanggal
       });

--- a/src/utils/purchaseHelpers.ts
+++ b/src/utils/purchaseHelpers.ts
@@ -77,11 +77,11 @@ export const filterPurchases = (
 
     // Amount range filter
     if (filters.amountRangeFilter.min !== null || filters.amountRangeFilter.max !== null) {
-      if (filters.amountRangeFilter.min !== null && purchase.totalNilai < filters.amountRangeFilter.min) {
+      if (filters.amountRangeFilter.min !== null && purchase.total_nilai < filters.amountRangeFilter.min) {
         return false;
       }
-      
-      if (filters.amountRangeFilter.max !== null && purchase.totalNilai > filters.amountRangeFilter.max) {
+
+      if (filters.amountRangeFilter.max !== null && purchase.total_nilai > filters.amountRangeFilter.max) {
         return false;
       }
     }
@@ -169,7 +169,7 @@ export const calculateItemTotal = (jumlah: number, hargaSatuan: number): number 
 
 export const calculateAverageOrderValue = (purchases: Purchase[]): number => {
   if (purchases.length === 0) return 0;
-  const total = purchases.reduce((sum, purchase) => sum + purchase.totalNilai, 0);
+  const total = purchases.reduce((sum, purchase) => sum + purchase.total_nilai, 0);
   return total / purchases.length;
 };
 
@@ -482,7 +482,7 @@ export const preparePurchasesForExport = (
       'ID': purchase.id,
       'Tanggal': formatPurchaseDate(purchase.tanggal),
       'Supplier': supplier?.nama || 'Unknown',
-      'Total Nilai': formatCurrency(purchase.totalNilai),
+      'Total Nilai': formatCurrency(purchase.total_nilai),
       'Status': getStatusDisplay(purchase.status).label,
       'Jumlah Item': purchase.items.length,
       'Dibuat': formatPurchaseDate(purchase.createdAt),

--- a/src/utils/purchaseValidation.ts
+++ b/src/utils/purchaseValidation.ts
@@ -28,7 +28,7 @@ export interface PurchaseValidationResult {
   errors: string[];
   warnings: string[];
   corrections: {
-    totalNilai: number;
+    total_nilai: number;
     items: PurchaseItem[];
   };
   qualityScore: number; // 0-100
@@ -154,7 +154,7 @@ export function validatePurchaseData(
       errors,
       warnings,
       corrections: {
-        totalNilai: calculatedTotal,
+        total_nilai: calculatedTotal,
         items: correctedItems
       },
       qualityScore
@@ -166,7 +166,7 @@ export function validatePurchaseData(
       isValid: false,
       errors: ['Validation error occurred'],
       warnings: [],
-      corrections: { totalNilai: 0, items: [] },
+      corrections: { total_nilai: 0, items: [] },
       qualityScore: 0
     };
   }

--- a/src/utils/testImportCalculation.ts
+++ b/src/utils/testImportCalculation.ts
@@ -20,7 +20,7 @@ export const testImportCalculation = async () => {
     const testImportPurchase = {
       supplier: 'TEST_SUPPLIER',
       tanggal: new Date(),
-      totalNilai: 50000, // Total payment: Rp 50,000
+      total_nilai: 50000, // Total payment: Rp 50,000
       items: [
         {
           bahanBakuId: '',
@@ -33,13 +33,13 @@ export const testImportCalculation = async () => {
         }
       ],
       status: 'pending' as const,
-      metodePerhitungan: 'AVERAGE' as const
+      metode_perhitungan: 'AVERAGE' as const
     };
 
     // Calculate what the price should be
-    const expectedUnitPrice = testImportPurchase.totalNilai / testImportPurchase.items[0].kuantitas;
+    const expectedUnitPrice = testImportPurchase.total_nilai / testImportPurchase.items[0].kuantitas;
     console.log('📊 [TEST IMPORT CALC] Expected calculation:', {
-      totalPayment: testImportPurchase.totalNilai,
+      totalPayment: testImportPurchase.total_nilai,
       quantity: testImportPurchase.items[0].kuantitas,
       expectedUnitPrice: expectedUnitPrice
     });
@@ -47,7 +47,7 @@ export const testImportCalculation = async () => {
     // Apply the same calculation logic as import
     const calculatedItems = testImportPurchase.items.map(item => {
       const calculatedUnitPrice = item.kuantitas > 0 
-        ? Math.round((testImportPurchase.totalNilai / item.kuantitas) * 100) / 100
+        ? Math.round((testImportPurchase.total_nilai / item.kuantitas) * 100) / 100
         : 0;
         
       const subtotal = item.kuantitas * calculatedUnitPrice;
@@ -56,7 +56,7 @@ export const testImportCalculation = async () => {
         ...item,
         hargaSatuan: calculatedUnitPrice,
         subtotal: subtotal,
-        keterangan: `[IMPORTED] Harga otomatis: Rp ${testImportPurchase.totalNilai.toLocaleString('id-ID')} ÷ ${item.kuantitas} = Rp ${calculatedUnitPrice.toLocaleString('id-ID')}`
+        keterangan: `[IMPORTED] Harga otomatis: Rp ${testImportPurchase.total_nilai.toLocaleString('id-ID')} ÷ ${item.kuantitas} = Rp ${calculatedUnitPrice.toLocaleString('id-ID')}`
       };
     });
 
@@ -79,7 +79,7 @@ export const testImportCalculation = async () => {
       if (verifyPurchase) {
         console.log('🔍 [TEST IMPORT CALC] Verification - created purchase:', {
           id: verifyPurchase.id,
-          totalNilai: verifyPurchase.totalNilai,
+          total_nilai: verifyPurchase.total_nilai,
           items: verifyPurchase.items.map(item => ({
             nama: item.nama,
             kuantitas: item.kuantitas,
@@ -143,7 +143,7 @@ export const testManualVsImportComparison = async () => {
     const testData = {
       supplier: 'TEST_SUPPLIER',
       tanggal: new Date(),
-      totalNilai: 30000,
+      total_nilai: 30000,
       quantity: 3,
       expectedUnitPrice: 10000
     };
@@ -152,7 +152,7 @@ export const testManualVsImportComparison = async () => {
     const manualPurchase = {
       supplier: testData.supplier,
       tanggal: testData.tanggal,
-      totalNilai: testData.totalNilai,
+      total_nilai: testData.total_nilai,
       items: [{
         bahanBakuId: '',
         nama: 'Manual Entry Test',
@@ -163,25 +163,25 @@ export const testManualVsImportComparison = async () => {
         keterangan: '[MANUAL] Manual entry test'
       }],
       status: 'pending' as const,
-      metodePerhitungan: 'AVERAGE' as const
+      metode_perhitungan: 'AVERAGE' as const
     };
 
     // Imported purchase (with automatic calculation)
     const importedPurchase = {
       supplier: testData.supplier,
       tanggal: testData.tanggal,
-      totalNilai: testData.totalNilai,
+      total_nilai: testData.total_nilai,
       items: [{
         bahanBakuId: '',
         nama: 'Import Entry Test',
         kuantitas: testData.quantity,
         satuan: 'pcs',
-        hargaSatuan: Math.round((testData.totalNilai / testData.quantity) * 100) / 100, // Auto-calculated
-        subtotal: testData.quantity * (testData.totalNilai / testData.quantity),
-        keterangan: `[IMPORTED] Harga otomatis: Rp ${testData.totalNilai.toLocaleString('id-ID')} ÷ ${testData.quantity} = Rp ${testData.expectedUnitPrice.toLocaleString('id-ID')}`
+        hargaSatuan: Math.round((testData.total_nilai / testData.quantity) * 100) / 100, // Auto-calculated
+        subtotal: testData.quantity * (testData.total_nilai / testData.quantity),
+        keterangan: `[IMPORTED] Harga otomatis: Rp ${testData.total_nilai.toLocaleString('id-ID')} ÷ ${testData.quantity} = Rp ${testData.expectedUnitPrice.toLocaleString('id-ID')}`
       }],
       status: 'pending' as const,
-      metodePerhitungan: 'AVERAGE' as const
+      metode_perhitungan: 'AVERAGE' as const
     };
 
     console.log('📋 [TEST COMPARISON] Creating manual purchase...');
@@ -202,13 +202,13 @@ export const testManualVsImportComparison = async () => {
         id: manualData?.id,
         unitPrice: manualData?.items[0]?.hargaSatuan,
         subtotal: manualData?.items[0]?.subtotal,
-        total: manualData?.totalNilai
+        total: manualData?.total_nilai
       });
       console.log('Import Purchase:', {
         id: importData?.id,
         unitPrice: importData?.items[0]?.hargaSatuan,
         subtotal: importData?.items[0]?.subtotal,
-        total: importData?.totalNilai
+        total: importData?.total_nilai
       });
       
       // Check if they're treated the same

--- a/src/utils/testImportedPurchaseSync.ts
+++ b/src/utils/testImportedPurchaseSync.ts
@@ -146,7 +146,7 @@ const createTestImportedPurchase = async (userId: string) => {
     const testPurchase = {
       supplier: 'Test Supplier',
       tanggal: new Date(),
-      totalNilai: 5000,
+      total_nilai: 5000,
       items: [{
         bahanBakuId: warehouseItem.id,
         nama: warehouseItem.nama,
@@ -157,7 +157,7 @@ const createTestImportedPurchase = async (userId: string) => {
         keterangan: '[IMPORTED] Test imported item'
       }],
       status: 'pending' as const,
-      metodePerhitungan: 'AVERAGE' as const
+      metode_perhitungan: 'AVERAGE' as const
     };
 
     const result = await PurchaseApiService.createPurchase(testPurchase, userId);

--- a/src/utils/unifiedTransformers.ts
+++ b/src/utils/unifiedTransformers.ts
@@ -156,7 +156,7 @@ export const PURCHASE_FIELD_MAPPINGS = {
     total_nilai: 'total_nilai',
     items: 'items',
     status: 'status',
-    metode_perhitungan: 'metodePerhitungan',
+    metode_perhitungan: 'metode_perhitungan',
     created_at: 'createdAt',
     updated_at: 'updatedAt'
   },
@@ -170,7 +170,7 @@ export const PURCHASE_FIELD_MAPPINGS = {
     total_nilai: 'total_nilai',
     items: 'items',
     status: 'status',
-    metodePerhitungan: 'metode_perhitungan',
+    metode_perhitungan: 'metode_perhitungan',
     createdAt: 'created_at',
     updatedAt: 'updated_at'
   }


### PR DESCRIPTION
## Ringkasan
- konsistenkan penggunaan field `total_nilai` pada tabel dan konteks pembelian
- sesuaikan hook dan utilitas import agar menyimpan `total_nilai` dan `metode_perhitungan` dengan benar

## Pengujian
- `pnpm lint` *(gagal: 1429 masalah lint)*

------
https://chatgpt.com/codex/tasks/task_e_68c73e78a158832ead379d156b9e8bd1