### PR TITLE
Expose showUpdateNotification from update hook

### DIFF
--- a/src/components/common/UpdateNotificationBanner.tsx
+++ b/src/components/common/UpdateNotificationBanner.tsx
@@ -230,6 +230,7 @@ export const useUpdateNotification = () => {
     updateInfo,
     isVisible,
     checkForUpdate, // Changed from showUpdateNotification
+    showUpdateNotification,
     hideUpdateNotification,
     dismissUpdateNotification
   };


### PR DESCRIPTION
## Summary
- expose `showUpdateNotification` from the `useUpdateNotification` hook so layouts can access it alongside `checkForUpdate`

## Testing
- pnpm lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4ad59360832ea63457a26f8c5b7d