### PR TITLE
fix: restore order transformer imports

### DIFF
--- a/src/components/orders/services/orderService.ts
+++ b/src/components/orders/services/orderService.ts
@@ -3,7 +3,8 @@ import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/utils/logger';
 import { toast } from 'sonner';
 import { orderEvents, emitOrderDeleted } from '../utils/orderEvents';
-import type { Order, OrderItem, CreateOrderData, UpdateOrderData } from '../types';
+import { transformOrderFromDB, transformOrderToDB } from '../utils';
+import type { Order, OrderItem, CreateOrderData, UpdateOrderData, OrderStatus } from '../types';
 
 // ✅ FIXED: Valid status values matching application values
 const VALID_ORDER_STATUSES: OrderStatus[] = ['pending', 'confirmed', 'preparing', 'ready', 'delivered', 'cancelled', 'completed'];


### PR DESCRIPTION
## Summary
- import the order transformer utilities in the order service to restore runtime availability
- bring the OrderStatus type into the service for consistent status validation

## Testing
- pnpm lint *(fails: existing repository-wide ESLint naming convention and typing violations)*
- pnpm build


------
https://chatgpt.com/codex/tasks/task_e_68cbcf47e1a4832e83809de50d7e001c