### PR TITLE
feat: improve bottom tab bar stickiness and spacing

### DIFF
--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -20,7 +20,7 @@ const BottomTabBar = () => {
   ];
 
   return (
-    <div className="fixed inset-x-0 bottom-0 md:hidden z-[200] border-t bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/90 pb-[env(safe-area-inset-bottom)] shadow-lg">
+    <div className="fixed inset-x-0 bottom-0 md:hidden z-[200] border-t bg-white pb-[env(safe-area-inset-bottom)] shadow-lg" style={{backgroundColor: 'white'}}>
       <div className="flex justify-around items-center h-16 px-2 max-w-md mx-auto w-full">
         {tabs.map(({ path, icon: Icon, label }) => {
           const isActive = location.pathname === path;

--- a/src/components/layout/MobileLayout.tsx
+++ b/src/components/layout/MobileLayout.tsx
@@ -43,7 +43,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = ({
       </header>
 
       {/* 📱 Main Content */}
-      <main className="flex-1 overflow-y-auto p-4 pb-20">
+      <main className="flex-1 overflow-y-auto p-4 pb-24" style={{paddingBottom: 'calc(5rem + env(safe-area-inset-bottom))'}}>
         <ErrorBoundary fallback={<AppError />}>
           {children}
         </ErrorBoundary>
@@ -54,7 +54,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = ({
 
       {/* 📱 Floating Payment Indicator */}
       {!isPaid && (
-        <div className="fixed bottom-20 right-4 z-50">
+        <div className="fixed right-4 z-50" style={{bottom: 'calc(5rem + env(safe-area-inset-bottom))'}}>
           <PaymentStatusIndicator size="lg" />
         </div>
       )}


### PR DESCRIPTION
- Made BottomTabBar background solid white (removed transparent backdrop)
- Added proper padding-bottom to main content to avoid content being hidden
- Used calc() with safe-area-inset-bottom for iOS notch support
- Adjusted floating payment indicator position above bottom bar
- Bottom bar now always visible and accessible without scrolling