### PR TITLE
fix(auth): remove redundant redirect check in EmailAuthPage

### DIFF
--- a/src/components/EmailAuthPage.tsx
+++ b/src/components/EmailAuthPage.tsx
@@ -524,8 +524,7 @@ const EmailAuthPage: React.FC<EmailAuthPageProps> = ({
           );
         }
 
-        // ✅ Let AuthContext handle SPA redirect to avoid duplicate navigations
-        redirectCheck();
+        // ✅ AuthContext will handle the redirect automatically via onAuthStateChange
 
         return;
       } else if (ok === "expired") {


### PR DESCRIPTION
Removes the manual `redirectCheck()` call from `EmailAuthPage` to prevent a race condition with the `onAuthStateChange` listener in `AuthContext`, which was causing a refresh loop.

refactor(device): improve device tracking and auth integration

- Defers device tracking until user is authenticated.
- Adds `isAuthenticated` memoization for better performance.
- Improves stability of device ID generation.