### PR TITLE
feat(auth): persist auth state on all devices

### DIFF
--- a/src/components/EmailAuthPage.tsx
+++ b/src/components/EmailAuthPage.tsx
@@ -63,7 +63,6 @@ const EmailAuthPage: React.FC<EmailAuthPageProps> = ({
       cooldownStartTime?: number;
       otpRequestTime?: number;
     }) => {
-      if (!isMobile) return; // Only persist on mobile
       try {
         const existing = JSON.parse(
           localStorage.getItem(AUTH_STORAGE_KEY) || "{}",
@@ -79,7 +78,6 @@ const EmailAuthPage: React.FC<EmailAuthPageProps> = ({
   );
 
   const loadAuthState = useCallback(() => {
-    if (!isMobile) return null;
     try {
       const stored = localStorage.getItem(AUTH_STORAGE_KEY);
       if (!stored) return null;


### PR DESCRIPTION
Removes the `isMobile` check from `saveAuthState` and `loadAuthState` to enable state persistence on all devices. This prevents the OTP page from resetting when switching tabs or applications on desktop.

fix(update): disable vercel deployment check

Disables the `checkDeploymentStatus` function to prevent calls to the `vercel-deployments` Supabase function. This removes the related log messages from the console.