### PR TITLE
fix(auth): simplify redirect logic

### DIFF
--- a/src/contexts/auth/useAuthManager.ts
+++ b/src/contexts/auth/useAuthManager.ts
@@ -569,32 +569,8 @@ const useAuthLifecycle = ({
         }
       }
 
-      if (validUser && window.location.pathname === "/auth") {
-        try {
-          // Prevent duplicate rapid navigations that can cause flicker and Chrome IPC flooding protection warnings
-          const w = window as any;
-          if (w.__AUTH_REDIRECTING__) {
-            logger.debug(
-              "AuthContext: Redirect already in flight, skipping duplicate",
-            );
-          } else {
-            w.__AUTH_REDIRECTING__ = true;
-            logger.info(
-              "AuthContext: 🚀 REDIRECTING authenticated user from /auth to / (SPA)",
-              {
-                userId: validUser.id,
-                email: validUser.email,
-                currentPath: window.location.pathname,
-                timestamp: new Date().toISOString(),
-              },
-            );
-            navigate("/", { replace: true });
-          }
-        } catch (redirectError) {
-          logger.error("AuthContext: Redirect error:", redirectError);
-          // Fallback to a single navigate attempt
-          navigate("/", { replace: true });
-        }
+      if (validUser) {
+        navigate("/", { replace: true });
       }
     });
 


### PR DESCRIPTION
Simplifies the redirect logic in the `onAuthStateChange` handler to redirect the user to the dashboard as soon as they are authenticated. This is a temporary solution to prevent the user from being stuck on the login page.