### PR TITLE
fix(auth): prevent multiple redirects

### DIFF
--- a/src/contexts/auth/useAuthManager.ts
+++ b/src/contexts/auth/useAuthManager.ts
@@ -569,7 +569,7 @@ const useAuthLifecycle = ({
         }
       }
 
-      if (validUser) {
+      if (validUser && window.location.pathname !== "/") {
         navigate("/", { replace: true });
       }
     });


### PR DESCRIPTION
Adds a condition to the `onAuthStateChange` handler to prevent the `navigate` function from being called multiple times. This solves the "Throttling navigation" issue and allows the user to be redirected to the dashboard.