### PR TITLE
fix: Critical session verification timeout and infinite loading fixes

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,1 +1,1 @@
-{"commitHash":"94cd1fd1e5c6247c2024331b0f8bdbbbe7c9a6a3"}
+{"commitHash":"9a673f6646bfacd3c8d8d81e54a18d33480dade1"}

--- a/src/contexts/auth/helpers.ts
+++ b/src/contexts/auth/helpers.ts
@@ -7,7 +7,7 @@ import type { Session, User } from '@supabase/supabase-js';
 
 type NetworkErrorPredicate = (message: string) => boolean;
 
-const MAX_TIMEOUT = 60000;
+const MAX_TIMEOUT = 8000; // Reduced from 60s to 8s to prevent long loading
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const NETWORK_ERROR_MATCHERS: ReadonlyArray<NetworkErrorPredicate> = [
   (message) => message.includes('network'),
@@ -29,7 +29,7 @@ export interface SafeWithTimeoutResult<T> {
 
 // detectDeviceCapabilities moved to @/utils/auth/deviceDetection
 
-export const getAdaptiveTimeout = (baseTimeout = 12000) => {
+export const getAdaptiveTimeout = (baseTimeout = 6000) => { // Reduced from 12s to 6s for faster auth
   const capabilities = detectDeviceCapabilities();
   const safariDetection = detectSafariIOS();
 


### PR DESCRIPTION
- Extended OTP verification window from 10s to 30s
- Added 8-second timeout protection to prevent infinite loading
- Reduced adaptive timeout from 12s to 6s for faster auth
- Reduced max timeout from 60s to 8s
- Added automatic redirect fallback if session verification fails
- Better loading UX with progress indicator
- Prevents infinite 'Memverifikasi sesi...' screens

Fixes the core issue where session verification takes too long and redirects back to auth.