### PR TITLE
refactor: modularize financial transaction table

### DIFF
--- a/src/components/financial/components/TransactionBulkActions.tsx
+++ b/src/components/financial/components/TransactionBulkActions.tsx
@@ -3,26 +3,18 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
-import { 
-  Trash2, 
-  X, 
-  CheckSquare, 
-  Square, 
+import {
+  Trash2,
+  X,
+  CheckSquare,
+  Square,
   AlertTriangle,
   Loader2
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/lib/shared';
-import { toast } from 'sonner';
 
-interface FinancialTransaction {
-  id: string;
-  date: Date | string | null;
-  description: string | null;
-  amount: number;
-  type: 'income' | 'expense';
-  category: string | null;
-}
+import type { FinancialTransaction } from '../types/financial';
 
 interface TransactionBulkActionsProps {
   selectedIds: string[];
@@ -61,16 +53,14 @@ const TransactionBulkActions: React.FC<TransactionBulkActionsProps> = ({
 
   const handleBulkDelete = async () => {
     if (selectedCount === 0) return;
-    
+
     setIsDeleting(true);
     try {
       await onBulkDelete(selectedIds);
       setShowConfirmDialog(false);
       onClearSelection();
-      toast.success(`${selectedCount} transaksi berhasil dihapus`);
     } catch (error) {
       console.error('Bulk delete error:', error);
-      toast.error('Gagal menghapus transaksi');
     } finally {
       setIsDeleting(false);
     }

--- a/src/components/financial/components/transaction-table/TransactionEmptyState.tsx
+++ b/src/components/financial/components/transaction-table/TransactionEmptyState.tsx
@@ -1,0 +1,43 @@
+import { Button } from '@/components/ui/button';
+import { TableCell, TableRow } from '@/components/ui/table';
+import { Plus } from 'lucide-react';
+
+interface TransactionEmptyStateProps {
+  colSpan: number;
+  dateRange?: { from: Date; to?: Date };
+  onAddTransaction?: () => void;
+}
+
+const TransactionEmptyState = ({
+  colSpan,
+  dateRange,
+  onAddTransaction,
+}: TransactionEmptyStateProps) => {
+  const message = dateRange
+    ? 'Tidak ada transaksi pada rentang tanggal ini.'
+    : 'Belum ada transaksi.';
+
+  return (
+    <TableRow>
+      <TableCell colSpan={colSpan} className="text-center h-24">
+        <div className="flex flex-col items-center justify-center">
+          <div className="text-gray-400 mb-2">📊</div>
+          <p className="text-gray-500">{message}</p>
+          {onAddTransaction && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onAddTransaction}
+              className="mt-2"
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Tambah Transaksi Pertama
+            </Button>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default TransactionEmptyState;

--- a/src/components/financial/components/transaction-table/TransactionPagination.tsx
+++ b/src/components/financial/components/transaction-table/TransactionPagination.tsx
@@ -1,0 +1,153 @@
+import { CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
+import { Fragment, useMemo } from 'react';
+
+interface TransactionPaginationProps {
+  itemsPerPage: number;
+  onItemsPerPageChange: (value: number) => void;
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+  startItem: number;
+  endItem: number;
+  onPageChange: (page: number) => void;
+  onNextPage: () => void;
+  onPreviousPage: () => void;
+}
+
+const MAX_VISIBLE_PAGES = 5;
+
+const TransactionPagination = ({
+  itemsPerPage,
+  onItemsPerPageChange,
+  currentPage,
+  totalPages,
+  totalItems,
+  startItem,
+  endItem,
+  onPageChange,
+  onNextPage,
+  onPreviousPage,
+}: TransactionPaginationProps) => {
+  const pageNumbers = useMemo(() => {
+    const pages: number[] = [];
+
+    if (totalPages <= MAX_VISIBLE_PAGES) {
+      for (let page = 1; page <= totalPages; page += 1) {
+        pages.push(page);
+      }
+      return pages;
+    }
+
+    const start = Math.max(1, currentPage - 2);
+    const end = Math.min(totalPages, start + MAX_VISIBLE_PAGES - 1);
+
+    for (let page = start; page <= end; page += 1) {
+      pages.push(page);
+    }
+
+    return pages;
+  }, [currentPage, totalPages]);
+
+  return (
+    <CardFooter className="flex flex-col sm:flex-row items-center justify-between p-4 border-t gap-4">
+      <div className="flex items-center gap-4 text-sm text-muted-foreground">
+        <div>
+          Menampilkan {startItem}-{endItem} dari {totalItems} transaksi
+        </div>
+        <div className="flex items-center gap-2">
+          <span>Per halaman:</span>
+          <Select
+            value={itemsPerPage.toString()}
+            onValueChange={value => onItemsPerPageChange(Number(value))}
+          >
+            <SelectTrigger className="w-16 h-8">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="5">5</SelectItem>
+              <SelectItem value="10">10</SelectItem>
+              <SelectItem value="20">20</SelectItem>
+              <SelectItem value="50">50</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onPreviousPage}
+            disabled={currentPage === 1}
+            className="px-3 disabled:opacity-50"
+          >
+            <ChevronLeft className="h-4 w-4 mr-1" />
+            Sebelumnya
+          </Button>
+
+          <div className="flex items-center gap-1 mx-2">
+            {pageNumbers.map(pageNum => (
+              <Fragment key={pageNum}>
+                {pageNum === 1 && currentPage > 3 && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onPageChange(1)}
+                      className="w-8 h-8 p-0"
+                    >
+                      1
+                    </Button>
+                    <div className="px-2">
+                      <MoreHorizontal className="h-4 w-4" />
+                    </div>
+                  </>
+                )}
+                <Button
+                  variant={currentPage === pageNum ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => onPageChange(pageNum)}
+                  className="w-8 h-8 p-0"
+                >
+                  {pageNum}
+                </Button>
+                {pageNum === totalPages && currentPage < totalPages - 2 && (
+                  <>
+                    <div className="px-2">
+                      <MoreHorizontal className="h-4 w-4" />
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onPageChange(totalPages)}
+                      className="w-8 h-8 p-0"
+                    >
+                      {totalPages}
+                    </Button>
+                  </>
+                )}
+              </Fragment>
+            ))}
+          </div>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onNextPage}
+            disabled={currentPage === totalPages}
+            className="px-3 disabled:opacity-50"
+          >
+            Selanjutnya
+            <ChevronRight className="h-4 w-4 ml-1" />
+          </Button>
+        </div>
+      )}
+    </CardFooter>
+  );
+};
+
+export default TransactionPagination;

--- a/src/components/financial/components/transaction-table/TransactionRows.tsx
+++ b/src/components/financial/components/transaction-table/TransactionRows.tsx
@@ -1,0 +1,259 @@
+import { memo, useCallback } from 'react';
+import { format } from 'date-fns';
+import { id } from 'date-fns/locale';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Edit, Info, Trash2 } from 'lucide-react';
+
+import { formatCurrency } from '@/lib/shared';
+
+import type { FinancialTransaction } from '../../types/financial';
+import TransactionEmptyState from './TransactionEmptyState';
+
+interface TransactionRowsProps {
+  transactions: FinancialTransaction[];
+  selectedIds: string[];
+  isSelectionMode: boolean;
+  isAllSelected: boolean;
+  onSelectAll?: () => void;
+  onSelectionChange?: (id: string, selected: boolean) => void;
+  onEditTransaction?: (transaction: FinancialTransaction) => void;
+  onDeleteTransaction: (transaction: FinancialTransaction) => void;
+  isDeleting: boolean;
+  getDisplayDescription: (description: string | null) => string;
+  dateRange?: { from: Date; to?: Date };
+  onAddTransaction?: () => void;
+}
+
+const TransactionRowComponent = ({
+  transaction,
+  isSelected,
+  onToggleSelect,
+  onEdit,
+  onDelete,
+  isDeleting,
+  getDisplayDescription,
+}: {
+  transaction: FinancialTransaction;
+  isSelected: boolean;
+  onToggleSelect?: (id: string, selected: boolean) => void;
+  onEdit?: (transaction: FinancialTransaction) => void;
+  onDelete: (transaction: FinancialTransaction) => void;
+  isDeleting: boolean;
+  getDisplayDescription: (description: string | null) => string;
+}) => {
+  const handleToggleSelect = useCallback(() => {
+    onToggleSelect?.(transaction.id, !isSelected);
+  }, [isSelected, onToggleSelect, transaction.id]);
+
+  const handleEdit = useCallback(() => {
+    onEdit?.(transaction);
+  }, [onEdit, transaction]);
+
+  const handleDelete = useCallback(() => {
+    onDelete(transaction);
+  }, [onDelete, transaction]);
+
+  return (
+    <TableRow className="hover:bg-gray-50">
+      {onToggleSelect && (
+        <TableCell className="w-12">
+          <Checkbox
+            checked={isSelected}
+            onCheckedChange={handleToggleSelect}
+            aria-label={`Pilih transaksi ${transaction.description}`}
+          />
+        </TableCell>
+      )}
+      <TableCell className="min-w-[140px]">
+        {transaction.date ? (
+          (() => {
+            try {
+              const date = new Date(transaction.date);
+              if (Number.isNaN(date.getTime())) {
+                return (
+                  <div className="text-gray-400 text-sm">
+                    <div>Tanggal tidak valid</div>
+                  </div>
+                );
+              }
+
+              const hasTimeInfo =
+                date.getHours() !== 0 ||
+                date.getMinutes() !== 0 ||
+                date.getSeconds() !== 0;
+              const dateStr = format(date, 'dd MMM yyyy', { locale: id });
+              const timeStr = format(date, 'HH:mm', { locale: id });
+
+              if (hasTimeInfo) {
+                return (
+                  <div className="text-sm">
+                    <div className="font-medium text-gray-900">{dateStr}</div>
+                    <div className="text-gray-500 text-xs">{timeStr} WIB</div>
+                  </div>
+                );
+              }
+
+              return (
+                <div className="text-sm">
+                  <div className="font-medium text-gray-900">{dateStr}</div>
+                  <div className="text-gray-400 text-xs">Tanggal saja</div>
+                </div>
+              );
+            } catch (error) {
+              return (
+                <div className="text-gray-400 text-sm">
+                  <div>Format tidak valid</div>
+                </div>
+              );
+            }
+          })()
+        ) : (
+          <div className="text-gray-400 text-sm">
+            <div>Tidak ada tanggal</div>
+          </div>
+        )}
+      </TableCell>
+      <TableCell className="max-w-[200px] truncate">
+        {getDisplayDescription(transaction.description)}
+      </TableCell>
+      <TableCell>
+        <Badge variant="outline">{transaction.category || 'Lainnya'}</Badge>
+      </TableCell>
+      <TableCell>
+        <Badge
+          variant={transaction.type === 'income' ? 'default' : 'destructive'}
+          className={
+            transaction.type === 'income'
+              ? 'bg-green-100 text-green-800 hover:bg-green-200'
+              : ''
+          }
+        >
+          {transaction.type === 'income' ? 'Pemasukan' : 'Pengeluaran'}
+        </Badge>
+      </TableCell>
+      <TableCell
+        className={`text-right font-medium ${
+          transaction.type === 'income' ? 'text-green-600' : 'text-red-600'
+        }`}
+      >
+        {formatCurrency(transaction.amount)}
+      </TableCell>
+      <TableCell className="text-right">
+        <div className="flex items-center justify-end gap-1">
+          {onEdit && (
+            <Button variant="ghost" size="sm" onClick={handleEdit}>
+              <Edit className="h-4 w-4" />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className="text-red-600 hover:text-red-700 hover:bg-red-50"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+const MemoizedTransactionRow = memo(TransactionRowComponent, (previous, next) => {
+  return (
+    previous.transaction.id === next.transaction.id &&
+    previous.transaction.updatedAt === next.transaction.updatedAt &&
+    previous.isSelected === next.isSelected &&
+    previous.isDeleting === next.isDeleting
+  );
+});
+MemoizedTransactionRow.displayName = 'MemoizedTransactionRow';
+
+const TransactionRows = ({
+  transactions,
+  selectedIds,
+  isSelectionMode,
+  isAllSelected,
+  onSelectAll,
+  onSelectionChange,
+  onEditTransaction,
+  onDeleteTransaction,
+  isDeleting,
+  getDisplayDescription,
+  dateRange,
+  onAddTransaction,
+}: TransactionRowsProps) => {
+  return (
+    <>
+      <TableHeader>
+        <TableRow>
+          {isSelectionMode && (
+            <TableHead className="w-12">
+              <Checkbox
+                checked={isAllSelected}
+                onCheckedChange={() => onSelectAll?.()}
+                aria-label="Pilih semua transaksi"
+              />
+            </TableHead>
+          )}
+          <TableHead className="min-w-[140px]">
+            <div className="flex items-center gap-2">
+              <span>Tanggal &amp; Waktu</span>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="h-3 w-3 text-gray-400 cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-xs">
+                    <div className="text-xs space-y-1">
+                      <p>
+                        <strong>Format tampilan:</strong>
+                      </p>
+                      <p>• Dengan waktu: "25 Des 2023" + "14:30 WIB"</p>
+                      <p>• Tanpa waktu: "25 Des 2023" + "Tanggal saja"</p>
+                      <p>• Waktu bersifat opsional saat input</p>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          </TableHead>
+          <TableHead>Deskripsi</TableHead>
+          <TableHead>Kategori</TableHead>
+          <TableHead>Tipe</TableHead>
+          <TableHead className="text-right">Jumlah</TableHead>
+          <TableHead className="text-right">Aksi</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {transactions.length > 0 ? (
+          transactions.map(transaction => (
+            <MemoizedTransactionRow
+              key={transaction.id}
+              transaction={transaction}
+              isSelected={selectedIds.includes(transaction.id)}
+              onToggleSelect={isSelectionMode ? onSelectionChange : undefined}
+              onEdit={onEditTransaction}
+              onDelete={onDeleteTransaction}
+              isDeleting={isDeleting}
+              getDisplayDescription={getDisplayDescription}
+            />
+          ))
+        ) : (
+          <TransactionEmptyState
+            colSpan={isSelectionMode ? 7 : 6}
+            dateRange={dateRange}
+            onAddTransaction={onAddTransaction}
+          />
+        )}
+      </TableBody>
+    </>
+  );
+};
+
+export default TransactionRows;

--- a/src/components/financial/components/transaction-table/TransactionTableToolbar.tsx
+++ b/src/components/financial/components/transaction-table/TransactionTableToolbar.tsx
@@ -1,0 +1,70 @@
+import { CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { RefreshCw, Plus } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import type { PaginationInfo } from '../../hooks/useTransactionData';
+
+interface TransactionTableToolbarProps {
+  lastUpdated?: Date;
+  onRefresh: () => void;
+  isRefreshing: boolean;
+  onAddTransaction?: () => void;
+  paginationInfo: PaginationInfo | null;
+}
+
+const TransactionTableToolbar = ({
+  lastUpdated,
+  onRefresh,
+  isRefreshing,
+  onAddTransaction,
+  paginationInfo,
+}: TransactionTableToolbarProps) => {
+  return (
+    <CardHeader>
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
+        <div className="flex items-center gap-2">
+          <CardTitle>Daftar Transaksi</CardTitle>
+          {lastUpdated && (
+            <div className="flex items-center gap-1 text-xs text-gray-500">
+              <div className="w-2 h-2 bg-green-500 rounded-full" />
+              Live
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRefresh}
+            disabled={isRefreshing}
+          >
+            <RefreshCw className={cn('mr-2 h-4 w-4', isRefreshing && 'animate-spin')} />
+            {isRefreshing ? 'Refreshing...' : 'Refresh'}
+          </Button>
+          {onAddTransaction && (
+            <Button size="sm" onClick={onAddTransaction}>
+              <Plus className="mr-2 h-4 w-4" />
+              Transaksi Baru
+            </Button>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center justify-between">
+        {lastUpdated && (
+          <p className="text-xs text-gray-400">
+            Terakhir diperbarui: {lastUpdated.toLocaleString('id-ID')}
+          </p>
+        )}
+        {paginationInfo && (
+          <p className="text-xs text-blue-600">
+            Mode: Server-side Pagination | Total: {paginationInfo.total} data
+          </p>
+        )}
+      </div>
+    </CardHeader>
+  );
+};
+
+export default TransactionTableToolbar;

--- a/src/components/financial/hooks/useTransactionBulkActions.ts
+++ b/src/components/financial/hooks/useTransactionBulkActions.ts
@@ -1,0 +1,68 @@
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { logger } from '@/utils/logger';
+
+import { bulkDeleteFinancialTransactions } from '../services/financialApi';
+
+const transactionQueryKeys = {
+  all: ['financial'] as const,
+};
+
+interface UseTransactionBulkActionsParams {
+  userId?: string;
+  onSuccess?: () => void;
+}
+
+interface BulkDeleteResult {
+  ids: string[];
+}
+
+export interface UseTransactionBulkActionsResult {
+  bulkDeleteTransactions: (ids: string[]) => Promise<BulkDeleteResult>;
+  isBulkDeleting: boolean;
+}
+
+export const useTransactionBulkActions = (
+  { userId, onSuccess }: UseTransactionBulkActionsParams = {},
+): UseTransactionBulkActionsResult => {
+  const queryClient = useQueryClient();
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: async (ids: string[]) => {
+      if (!userId) {
+        throw new Error('User belum terautentikasi');
+      }
+
+      await bulkDeleteFinancialTransactions(ids, userId);
+      return { ids } satisfies BulkDeleteResult;
+    },
+    onSuccess: ({ ids }) => {
+      queryClient.invalidateQueries({ queryKey: transactionQueryKeys.all });
+      onSuccess?.();
+
+      toast.success(`${ids.length} transaksi berhasil dihapus`);
+    },
+    onError: (error: Error) => {
+      logger.error('Bulk delete failed:', error);
+      toast.error(`Gagal menghapus transaksi: ${error.message}`);
+    },
+  });
+
+  const bulkDeleteTransactions = useCallback(
+    async (ids: string[]) => {
+      if (ids.length === 0) {
+        return { ids };
+      }
+
+      return bulkDeleteMutation.mutateAsync(ids);
+    },
+    [bulkDeleteMutation],
+  );
+
+  return {
+    bulkDeleteTransactions,
+    isBulkDeleting: bulkDeleteMutation.isPending,
+  };
+};

--- a/src/components/financial/hooks/useTransactionData.ts
+++ b/src/components/financial/hooks/useTransactionData.ts
@@ -1,0 +1,291 @@
+import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { logger } from '@/utils/logger';
+
+import {
+  deleteFinancialTransaction,
+  getFinancialTransactionsPaginated,
+  getTransactionsByDateRange,
+} from '../services/financialApi';
+import type { FinancialTransaction } from '../types/financial';
+
+const transactionQueryKeys = {
+  all: ['financial'] as const,
+  list: () => [...transactionQueryKeys.all, 'transactions'] as const,
+  byRange: (from: Date, to?: Date) =>
+    [...transactionQueryKeys.list(), 'range', from.toISOString(), to?.toISOString()] as const,
+  paginated: (
+    page: number,
+    limit: number,
+    from?: Date,
+    to?: Date,
+  ) =>
+    [
+      ...transactionQueryKeys.list(),
+      'paginated',
+      page,
+      limit,
+      from?.toISOString(),
+      to?.toISOString(),
+    ] as const,
+};
+
+interface LegacyTransactionData {
+  transactions: FinancialTransaction[];
+  isLoading?: boolean;
+  onRefresh?: () => void;
+}
+
+interface UseTransactionDataParams {
+  dateRange?: { from: Date; to?: Date };
+  userId?: string;
+  useServerPagination: boolean;
+  initialItemsPerPage: number;
+  legacyData?: LegacyTransactionData;
+  enabled?: boolean;
+}
+
+export interface PaginationInfo {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface UseTransactionDataResult {
+  transactions: FinancialTransaction[];
+  visibleTransactions: FinancialTransaction[];
+  paginationInfo: PaginationInfo | null;
+  totalItems: number;
+  totalPages: number;
+  startItem: number;
+  endItem: number;
+  itemsPerPage: number;
+  setItemsPerPage: (value: number) => void;
+  currentPage: number;
+  handlePageChange: (page: number) => void;
+  handleNextPage: () => void;
+  handlePreviousPage: () => void;
+  isLoading: boolean;
+  isRefetching: boolean;
+  showInitialLoading: boolean;
+  showBackgroundLoading: boolean;
+  onRefresh: () => void;
+  lastUpdated?: Date;
+  deleteTransaction: (id: string) => Promise<boolean>;
+  isDeleting: boolean;
+  error: unknown;
+  hasTransactions: boolean;
+}
+
+const MAX_VISIBLE_ROWS = 10;
+
+export const useTransactionData = ({
+  dateRange,
+  userId,
+  useServerPagination,
+  initialItemsPerPage,
+  legacyData,
+  enabled = true,
+}: UseTransactionDataParams): UseTransactionDataResult => {
+  const [itemsPerPage, setItemsPerPage] = useState(initialItemsPerPage);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const queryClient = useQueryClient();
+
+  const hasLegacyTransactions = Boolean(legacyData?.transactions);
+  const shouldFetch = enabled && !hasLegacyTransactions && Boolean(userId);
+
+  const { data, isLoading, error, refetch, dataUpdatedAt, isRefetching } = useQuery({
+    queryKey: useServerPagination
+      ? transactionQueryKeys.paginated(
+          currentPage,
+          itemsPerPage,
+          dateRange?.from,
+          dateRange?.to,
+        )
+      : dateRange
+        ? transactionQueryKeys.byRange(dateRange.from, dateRange.to)
+        : transactionQueryKeys.list(),
+    queryFn: async () => {
+      if (!userId) {
+        return useServerPagination
+          ? { data: [], total: 0, page: 1, limit: itemsPerPage, totalPages: 0 }
+          : [];
+      }
+
+      if (useServerPagination) {
+        return getFinancialTransactionsPaginated(userId, {
+          page: currentPage,
+          limit: itemsPerPage,
+        });
+      }
+
+      if (!dateRange?.from || !dateRange?.to) {
+        return [];
+      }
+
+      return getTransactionsByDateRange(userId, dateRange.from, dateRange.to);
+    },
+    enabled: shouldFetch,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    refetchInterval: false,
+    retry: 1,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteFinancialTransaction(id),
+    onSuccess: success => {
+      if (success) {
+        queryClient.invalidateQueries({ queryKey: transactionQueryKeys.list() });
+        toast.success('Transaksi berhasil dihapus');
+      } else {
+        toast.error('Gagal menghapus transaksi');
+      }
+    },
+    onError: (mutationError: Error) => {
+      logger.error('Failed to delete transaction:', mutationError);
+      toast.error(
+        `Gagal menghapus transaksi: ${
+          mutationError instanceof Error ? mutationError.message : String(mutationError)
+        }`,
+      );
+    },
+  });
+
+  const isPaginatedResponse = (value: unknown): value is { data: FinancialTransaction[] } & PaginationInfo => {
+    return Boolean(
+      value &&
+        typeof value === 'object' &&
+        'data' in value &&
+        'total' in value &&
+        'page' in value &&
+        'limit' in value &&
+        'totalPages' in value,
+    );
+  };
+
+  const fetchedTransactions = useMemo(() => {
+    if (useServerPagination && isPaginatedResponse(data)) {
+      return data.data;
+    }
+
+    return (data as FinancialTransaction[]) ?? [];
+  }, [data, useServerPagination]);
+
+  const paginationInfo = useMemo(() => {
+    if (useServerPagination && !hasLegacyTransactions && isPaginatedResponse(data)) {
+      const { total, page, limit, totalPages } = data;
+      return { total, page, limit, totalPages };
+    }
+
+    return null;
+  }, [data, hasLegacyTransactions, useServerPagination]);
+
+  const transactions = legacyData?.transactions ?? fetchedTransactions;
+  const totalItems = paginationInfo ? paginationInfo.total : transactions.length;
+  const totalPages = paginationInfo
+    ? paginationInfo.totalPages
+    : transactions.length > 0
+      ? Math.ceil(transactions.length / itemsPerPage)
+      : 0;
+
+  const visibleTransactions = useMemo(() => {
+    if (!hasLegacyTransactions && paginationInfo) {
+      return fetchedTransactions.slice(0, Math.min(fetchedTransactions.length, MAX_VISIBLE_ROWS));
+    }
+
+    const firstItemIndex = (currentPage - 1) * itemsPerPage;
+    const sliced = transactions.slice(firstItemIndex, firstItemIndex + itemsPerPage);
+    return sliced.slice(0, Math.min(sliced.length, MAX_VISIBLE_ROWS));
+  }, [
+    currentPage,
+    fetchedTransactions,
+    hasLegacyTransactions,
+    itemsPerPage,
+    paginationInfo,
+    transactions,
+  ]);
+
+  const startItem = totalItems === 0 ? 0 : (currentPage - 1) * itemsPerPage + 1;
+  const endItem = paginationInfo
+    ? Math.min(currentPage * itemsPerPage, paginationInfo.total)
+    : Math.min(currentPage * itemsPerPage, transactions.length);
+
+  useEffect(() => {
+    if (totalPages > 0 && currentPage > totalPages) {
+      setCurrentPage(1);
+    }
+  }, [currentPage, totalPages]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [itemsPerPage, useServerPagination]);
+
+  const handlePageChange = useCallback((page: number) => {
+    setCurrentPage(page);
+  }, []);
+
+  const handleNextPage = useCallback(() => {
+    setCurrentPage(prev => Math.min(prev + 1, Math.max(totalPages, 1)));
+  }, [totalPages]);
+
+  const handlePreviousPage = useCallback(() => {
+    setCurrentPage(prev => Math.max(prev - 1, 1));
+  }, []);
+
+  const combinedIsLoading = hasLegacyTransactions
+    ? legacyData?.isLoading ?? false
+    : shouldFetch
+      ? isLoading
+      : false;
+
+  const combinedIsRefetching = hasLegacyTransactions
+    ? Boolean(legacyData?.isLoading && transactions.length > 0)
+    : shouldFetch
+      ? isRefetching
+      : false;
+
+  const showInitialLoading = combinedIsLoading && transactions.length === 0;
+  const showBackgroundLoading = combinedIsRefetching && transactions.length > 0;
+
+  const onRefresh = useCallback(() => {
+    if (hasLegacyTransactions) {
+      legacyData?.onRefresh?.();
+      return;
+    }
+
+    void refetch();
+  }, [hasLegacyTransactions, legacyData, refetch]);
+
+  return {
+    transactions,
+    visibleTransactions,
+    paginationInfo,
+    totalItems,
+    totalPages,
+    startItem,
+    endItem,
+    itemsPerPage,
+    setItemsPerPage,
+    currentPage,
+    handlePageChange,
+    handleNextPage,
+    handlePreviousPage,
+    isLoading: combinedIsLoading,
+    isRefetching: combinedIsRefetching,
+    showInitialLoading,
+    showBackgroundLoading,
+    onRefresh,
+    lastUpdated: !hasLegacyTransactions && dataUpdatedAt ? new Date(dataUpdatedAt) : undefined,
+    deleteTransaction: deleteMutation.mutateAsync,
+    isDeleting: deleteMutation.isPending,
+    error: shouldFetch ? error : null,
+    hasTransactions: transactions.length > 0,
+  };
+};


### PR DESCRIPTION
## Summary
- tambahkan hook `useTransactionData` untuk menyatukan fetch transaksi, paginasi, dan mutasi hapus sehingga bisa dipakai ulang oleh tabel transaksi finansial
- siapkan hook `useTransactionBulkActions` lalu hubungkan konsumennya termasuk komponen filter agar bulk delete memakai logika terpusat
- pecah `TransactionTable` menjadi toolbar, rows, pagination, dan empty state yang lebih kecil serta sesuaikan `TransactionBulkActions`

## Testing
- `pnpm lint` *(gagal karena konfigurasi lint global men-scan berkas build `dev-dist` dan rule @typescript-eslint tidak tersedia serta parse error lama pada `src/config/smartLazyLoading.ts`)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ce62fb5eb0832e827f863098a28583