### PR TITLE
fix: guard promo calculator input handlers

### DIFF
--- a/src/components/promoCalculator/PromoFullCalculator.tsx
+++ b/src/components/promoCalculator/PromoFullCalculator.tsx
@@ -20,8 +20,8 @@ import {
   PromoCalculationStep
 } from './components';
 const PromoFullCalculator = () => {
-  const [showCreatorHint, setShowCreatorHint] = React.useState<boolean>(false);
-  React.useEffect(() => {
+  const [showCreatorHint, setShowCreatorHint] = useState(false);
+  useEffect(() => {
     try {
       const dismissed = localStorage.getItem('promoCreatorHintDismissed');
       setShowCreatorHint(!dismissed);
@@ -106,13 +106,6 @@ const PromoFullCalculator = () => {
         return <PromoBasicInfoStep {...stepProps} />;
     }
   };
-
-  // Memoized calculate function
-  const handleCalculate = useCallback(() => {
-    if (calculate && formData) {
-      calculate(formData);
-    }
-  }, [calculate, formData]);
 
   // Loading state
   if (isEditMode && isLoading) {
@@ -243,7 +236,7 @@ const PromoFullCalculator = () => {
                 calculationResult={calculationResult}
                 onPrevStep={prevStep}
                 onNextStep={nextStep}
-                onCalculate={() => calculate && formData && calculate(formData)}
+                onCalculate={handleCalculate}
                 onSave={handleSave}
               />
             )}

--- a/src/components/promoCalculator/components/steps/PromoBasicInfoStep.tsx
+++ b/src/components/promoCalculator/components/steps/PromoBasicInfoStep.tsx
@@ -16,6 +16,28 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
   onInputChange,
   onSelectChange
 }) => {
+  const handleBasicInputChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+      if (onInputChange) {
+        onInputChange(event);
+      } else {
+        console.warn('PromoBasicInfoStep: handler onInputChange tidak tersedia');
+      }
+    },
+    [onInputChange]
+  );
+
+  const handlePromoTypeChange = React.useCallback(
+    (value: string) => {
+      if (onSelectChange) {
+        onSelectChange('tipePromo', value);
+      } else {
+        console.warn('PromoBasicInfoStep: handler onSelectChange tidak tersedia');
+      }
+    },
+    [onSelectChange]
+  );
+
   return (
     <Card>
       <CardHeader>
@@ -32,12 +54,12 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
           <Input
             id="namaPromo"
             value={formData.namaPromo}
-            onChange={(e) => onInputChange(e)}
+            onChange={handleBasicInputChange}
             placeholder="Contoh: Diskon Akhir Tahun 25%"
             className={`mt-1 ${
-              stepErrors?.some(error => error.includes('Nama promo')) 
-                ? 'border-red-500 focus:border-red-500' 
-                : formData.namaPromo.length >= 3 
+              stepErrors?.some(error => error.includes('Nama promo'))
+                ? 'border-red-500 focus:border-red-500'
+                : formData.namaPromo.length >= 3
                 ? 'border-green-500' 
                 : ''
             }`}
@@ -64,17 +86,7 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
           </Label>
           <Select
             value={formData.tipePromo || ''}
-            onValueChange={(value) => {
-              if (onSelectChange && typeof onSelectChange === 'function') {
-                try {
-                  onSelectChange('tipePromo', value);
-                } catch (error) {
-                  console.error('Error calling onSelectChange:', error);
-                }
-              } else {
-                console.warn('onSelectChange is not a function:', typeof onSelectChange);
-              }
-            }}
+            onValueChange={handlePromoTypeChange}
           >
             <SelectTrigger className="mt-1">
               <SelectValue placeholder="Pilih tipe promo" />
@@ -115,7 +127,7 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
           <Textarea
             id="deskripsi"
             value={formData.deskripsi}
-            onChange={(e) => onInputChange(e)}
+            onChange={handleBasicInputChange}
             placeholder="Contoh: Berlaku untuk pembelian minimal 2 item, tidak dapat digabung dengan promo lain..."
             rows={4}
             className="mt-1"
@@ -134,7 +146,7 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
               id="tanggalMulai"
               type="date"
               value={formData.tanggalMulai}
-              onChange={(e) => onInputChange(e)}
+              onChange={handleBasicInputChange}
               className="mt-1"
             />
           </div>
@@ -146,7 +158,7 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
               id="tanggalSelesai"
               type="date"
               value={formData.tanggalSelesai}
-              onChange={(e) => onInputChange(e)}
+              onChange={handleBasicInputChange}
               className="mt-1"
             />
           </div>

--- a/src/components/promoCalculator/components/steps/PromoSettingsStep.tsx
+++ b/src/components/promoCalculator/components/steps/PromoSettingsStep.tsx
@@ -11,9 +11,19 @@ import type { PromoFormStepProps } from '../../types/promo.types';
 export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
   formData,
   stepErrors,
-  onInputChange,
-  onSelectChange
+  onInputChange
 }) => {
+  const handleSettingsInputChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+      if (onInputChange) {
+        onInputChange(event);
+      } else {
+        console.warn('PromoSettingsStep: handler onInputChange tidak tersedia');
+      }
+    },
+    [onInputChange]
+  );
+
   return (
     <Card>
       <CardHeader>
@@ -37,12 +47,12 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                 inputMode="numeric"
                 pattern="[0-9]*"
                 value={formData.hargaProduk}
-                onChange={(e) => onInputChange(e)}
+                onChange={handleSettingsInputChange}
                 placeholder="50000"
                 className={`mt-1 ${
-                  stepErrors?.some(error => error.includes('Harga produk')) 
-                    ? 'border-red-500 focus:border-red-500' 
-                    : formData.hargaProduk && parseFloat(formData.hargaProduk) > 0 
+                  stepErrors?.some(error => error.includes('Harga produk'))
+                    ? 'border-red-500 focus:border-red-500'
+                    : formData.hargaProduk && parseFloat(formData.hargaProduk) > 0
                     ? 'border-green-500' 
                     : ''
                 }`}
@@ -67,11 +77,11 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                 inputMode="numeric"
                 pattern="[0-9]*"
                 value={formData.hpp}
-                onChange={(e) => onInputChange(e)}
+                onChange={handleSettingsInputChange}
                 placeholder="30000"
                 className={`mt-1 ${
-                  stepErrors?.some(error => error.includes('HPP')) 
-                    ? 'border-red-500 focus:border-red-500' 
+                  stepErrors?.some(error => error.includes('HPP'))
+                    ? 'border-red-500 focus:border-red-500'
                     : formData.hpp && parseFloat(formData.hpp) > 0 && formData.hargaProduk && parseFloat(formData.hpp) < parseFloat(formData.hargaProduk)
                     ? 'border-green-500' 
                     : ''
@@ -98,12 +108,12 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                 inputMode="numeric"
                 pattern="[0-9]*"
                 value={formData.nilaiDiskon}
-                onChange={(e) => onInputChange(e)}
+                onChange={handleSettingsInputChange}
                 placeholder="25"
                 min="0"
                 max="100"
                 className={`mt-1 ${
-                  stepErrors?.some(error => error.includes('Nilai diskon')) 
+                  stepErrors?.some(error => error.includes('Nilai diskon'))
                     ? 'border-red-500 focus:border-red-500' 
                     : formData.nilaiDiskon && parseFloat(formData.nilaiDiskon) > 0 && parseFloat(formData.nilaiDiskon) <= 100
                     ? 'border-green-500' 
@@ -134,12 +144,12 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                     inputMode="numeric"
                     pattern="[0-9]*"
                     value={formData.beli}
-                    onChange={(e) => onInputChange(e)}
+                    onChange={handleSettingsInputChange}
                     placeholder="2"
                     min="1"
                     className={`mt-1 ${
-                      stepErrors?.some(error => error.includes('Jumlah beli')) 
-                        ? 'border-red-500 focus:border-red-500' 
+                      stepErrors?.some(error => error.includes('Jumlah beli'))
+                        ? 'border-red-500 focus:border-red-500'
                         : formData.beli && parseInt(formData.beli) > 0
                         ? 'border-green-500' 
                         : ''
@@ -161,12 +171,12 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                     inputMode="numeric"
                     pattern="[0-9]*"
                     value={formData.gratis}
-                    onChange={(e) => onInputChange(e)}
+                    onChange={handleSettingsInputChange}
                     placeholder="1"
                     min="1"
                     className={`mt-1 ${
-                      stepErrors?.some(error => error.includes('Jumlah gratis')) 
-                        ? 'border-red-500 focus:border-red-500' 
+                      stepErrors?.some(error => error.includes('Jumlah gratis'))
+                        ? 'border-red-500 focus:border-red-500'
                         : formData.gratis && parseInt(formData.gratis) > 0
                         ? 'border-green-500' 
                         : ''
@@ -197,11 +207,11 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                   inputMode="numeric"
                   pattern="[0-9]*"
                   value={formData.hargaNormal}
-                  onChange={(e) => onInputChange(e)}
+                  onChange={handleSettingsInputChange}
                   placeholder="100000"
                   className={`mt-1 ${
-                    stepErrors?.some(error => error.includes('Harga normal')) 
-                      ? 'border-red-500 focus:border-red-500' 
+                    stepErrors?.some(error => error.includes('Harga normal'))
+                      ? 'border-red-500 focus:border-red-500'
                       : formData.hargaNormal && parseFloat(formData.hargaNormal) > 0
                       ? 'border-green-500' 
                       : ''
@@ -223,11 +233,11 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                   inputMode="numeric"
                   pattern="[0-9]*"
                   value={formData.hargaBundle}
-                  onChange={(e) => onInputChange(e)}
+                  onChange={handleSettingsInputChange}
                   placeholder="80000"
                   className={`mt-1 ${
-                    stepErrors?.some(error => error.includes('Harga bundle')) 
-                      ? 'border-red-500 focus:border-red-500' 
+                    stepErrors?.some(error => error.includes('Harga bundle'))
+                      ? 'border-red-500 focus:border-red-500'
                       : formData.hargaBundle && parseFloat(formData.hargaBundle) > 0 && formData.hargaNormal && parseFloat(formData.hargaBundle) < parseFloat(formData.hargaNormal)
                       ? 'border-green-500' 
                       : ''

--- a/src/components/promoCalculator/components/steps/PromoStatusStep.tsx
+++ b/src/components/promoCalculator/components/steps/PromoStatusStep.tsx
@@ -15,9 +15,19 @@ interface PromoStatusStepProps extends PromoFormStepProps {
 export const PromoStatusStep: React.FC<PromoStatusStepProps> = ({
   formData,
   stepErrors,
-  onInputChange,
   onSelectChange
 }) => {
+  const handleStatusChange = React.useCallback(
+    (value: string) => {
+      if (onSelectChange) {
+        onSelectChange('status', value);
+      } else {
+        console.warn('PromoStatusStep: handler onSelectChange tidak tersedia');
+      }
+    },
+    [onSelectChange]
+  );
+
   return (
     <Card>
       <CardHeader>
@@ -33,11 +43,7 @@ export const PromoStatusStep: React.FC<PromoStatusStepProps> = ({
           </Label>
           <Select
             value={formData.status || ''}
-            onValueChange={(value) => {
-              if (typeof onSelectChange === 'function') {
-                onSelectChange('status', value);
-              }
-            }}
+            onValueChange={handleStatusChange}
           >
             <SelectTrigger className="mt-1">
               <SelectValue placeholder="Pilih status" />

--- a/src/components/promoCalculator/types/promo.types.ts
+++ b/src/components/promoCalculator/types/promo.types.ts
@@ -60,8 +60,11 @@ export interface PromoWizardProps {
 export interface PromoFormStepProps {
   formData: PromoFormData;
   stepErrors: string[];
-  onInputChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement> | string, value?: string) => void;
-  onSelectChange: (name: string, value: string) => void;
+  onInputChange?: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement> | string,
+    value?: string
+  ) => void;
+  onSelectChange?: (name: string, value: string) => void;
 }
 
 export interface PromoCalculationDisplayProps {


### PR DESCRIPTION
## Summary
- tambahkan pengaman handler input/select pada langkah-langkah promo supaya tidak melempar TypeError ketika handler tidak tersedia
- jadikan properti handler pada `PromoFormStepProps` opsional dan log peringatan ketika handler hilang
- rapikan kalkulasi promo di kontainer utama agar memakai fungsi ter-memo secara konsisten

## Testing
- pnpm lint *(gagal: lint global masih mencari rule @typescript-eslint yang tidak tersedia dan error parsing bawaan)*
- pnpm build


------
https://chatgpt.com/codex/tasks/task_e_68cfa3e8142c832e81320cda17942a00