### PR TITLE
refactor: reuse centralized session refresh helper

### DIFF
--- a/src/components/operational-costs/hooks/useOperationalCostAuth.ts
+++ b/src/components/operational-costs/hooks/useOperationalCostAuth.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { refreshSession as refreshSessionInternal } from '@/services/auth';
 import { logger } from '@/utils/logger';
 import { OPERATIONAL_COST_QUERY_KEYS } from './useOperationalCostQuery';
 
@@ -185,18 +186,18 @@ export const useOperationalCostAuth = ({
   const refreshSession = useCallback(async () => {
     try {
       logger.info('🔐 Refreshing session');
-      const { data, error } = await supabase.auth.refreshSession();
-      
-      if (error) {
-        logger.error('🔐 Session refresh error:', error);
+      const session = await refreshSessionInternal();
+
+      if (!session?.user) {
+        logger.error('🔐 Session refresh returned no active session');
         setIsAuthenticated(false);
         if (onError) {
           onError('Sesi berakhir, silakan login kembali');
         }
         return false;
       }
-      
-      const isAuth = !!data.session?.user;
+
+      const isAuth = !!session.user;
       setIsAuthenticated(isAuth);
       logger.info('🔐 Session refreshed successfully');
       return isAuth;

--- a/src/hooks/auth/useAuthLifecycle.ts
+++ b/src/hooks/auth/useAuthLifecycle.ts
@@ -400,10 +400,18 @@ export const useAuthLifecycle = ({
               break;
             }
 
-            const refreshed = await refreshSessionSafely();
-            if (refreshed) {
+            const refreshedSession = await refreshSessionSafely();
+            if (refreshedSession) {
               logger.debug(
                 "AuthContext: refreshSessionSafely succeeded before retry",
+                {
+                  attempt,
+                  userId: refreshedSession.user?.id,
+                },
+              );
+            } else {
+              logger.warn(
+                "AuthContext: refreshSessionSafely returned no session before retry",
                 {
                   attempt,
                 },

--- a/src/hooks/auth/useAuthValidation.ts
+++ b/src/hooks/auth/useAuthValidation.ts
@@ -40,34 +40,16 @@ export const useAuthValidation = ({
       if (timeoutError) {
         logger.error("AuthContext refresh timeout/error", timeoutError);
 
-        const refreshSuccess = await refreshSessionSafely();
-        if (!refreshSuccess) {
+        const refreshedSession = await refreshSessionSafely();
+        if (!refreshedSession) {
           logger.warn("AuthContext: Both getSession and refreshSession failed");
           return;
         }
 
-        const { data: retryResult } = await safeWithTimeout(
-          () => supabase.auth.getSession(),
-          {
-            timeoutMs: adaptiveTimeout,
-            timeoutMessage: "AuthContext refresh retry",
-          },
-        );
-
-        if (retryResult) {
-          const {
-            data: { session: retrySession },
-            error,
-          } = retryResult as GetSessionResult;
-
-          if (!error) {
-            const { session: validSession, user: validUser } =
-              validateSession(retrySession);
-            updateSession(validSession);
-            updateUser(validUser);
-            return;
-          }
-        }
+        const { session: validSession, user: validUser } =
+          validateSession(refreshedSession);
+        updateSession(validSession);
+        updateUser(validUser);
         return;
       }
 


### PR DESCRIPTION
## Summary
- gunakan helper `refreshSession` ber-mutex dari layer service untuk implementasi `refreshSessionSafely`
- sinkronkan hook lifecycle dan validation agar memanfaatkan sesi hasil refresh serta menangani kegagalan tanpa memanggil Supabase langsung
- gunakan hasil refresh terpusat di auth core dan hook operational cost supaya sukses berdasarkan sesi yang valid

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfa62861c0832e9fe28259658a8dff