### PR TITLE
fix: enable promo form inputs

### DIFF
--- a/src/components/promoCalculator/components/steps/PromoBasicInfoStep.tsx
+++ b/src/components/promoCalculator/components/steps/PromoBasicInfoStep.tsx
@@ -53,6 +53,7 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
           </Label>
           <Input
             id="namaPromo"
+            name="namaPromo"
             value={formData.namaPromo}
             onChange={handleBasicInputChange}
             placeholder="Contoh: Diskon Akhir Tahun 25%"
@@ -126,6 +127,7 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
           </Label>
           <Textarea
             id="deskripsi"
+            name="deskripsi"
             value={formData.deskripsi}
             onChange={handleBasicInputChange}
             placeholder="Contoh: Berlaku untuk pembelian minimal 2 item, tidak dapat digabung dengan promo lain..."
@@ -144,6 +146,7 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
             </Label>
             <Input
               id="tanggalMulai"
+              name="tanggalMulai"
               type="date"
               value={formData.tanggalMulai}
               onChange={handleBasicInputChange}
@@ -156,6 +159,7 @@ export const PromoBasicInfoStep: React.FC<PromoFormStepProps> = ({
             </Label>
             <Input
               id="tanggalSelesai"
+              name="tanggalSelesai"
               type="date"
               value={formData.tanggalSelesai}
               onChange={handleBasicInputChange}

--- a/src/components/promoCalculator/components/steps/PromoSettingsStep.tsx
+++ b/src/components/promoCalculator/components/steps/PromoSettingsStep.tsx
@@ -43,6 +43,7 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
               </Label>
               <Input
                 id="hargaProduk"
+                name="hargaProduk"
                 type="number"
                 inputMode="numeric"
                 pattern="[0-9]*"
@@ -73,6 +74,7 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
               </Label>
               <Input
                 id="hpp"
+                name="hpp"
                 type="number"
                 inputMode="numeric"
                 pattern="[0-9]*"
@@ -104,6 +106,7 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
               </Label>
               <Input
                 id="nilaiDiskon"
+                name="nilaiDiskon"
                 type="number"
                 inputMode="numeric"
                 pattern="[0-9]*"
@@ -140,6 +143,7 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                   </Label>
                   <Input
                     id="beli"
+                    name="beli"
                     type="number"
                     inputMode="numeric"
                     pattern="[0-9]*"
@@ -167,6 +171,7 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                   </Label>
                   <Input
                     id="gratis"
+                    name="gratis"
                     type="number"
                     inputMode="numeric"
                     pattern="[0-9]*"
@@ -203,6 +208,7 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                 </Label>
                 <Input
                   id="hargaNormal"
+                  name="hargaNormal"
                   type="number"
                   inputMode="numeric"
                   pattern="[0-9]*"
@@ -229,6 +235,7 @@ export const PromoSettingsStep: React.FC<PromoFormStepProps> = ({
                 </Label>
                 <Input
                   id="hargaBundle"
+                  name="hargaBundle"
                   type="number"
                   inputMode="numeric"
                   pattern="[0-9]*"

--- a/src/components/promoCalculator/hooks/usePromoForm.ts
+++ b/src/components/promoCalculator/hooks/usePromoForm.ts
@@ -222,7 +222,7 @@ export const usePromoForm = (id?: string) => {
     // Handle both event object and direct value calls
     let fieldName: string;
     let fieldValue: string;
-    
+
     if (typeof e === 'string') {
       // Direct call with field name and value
       fieldName = e;
@@ -230,14 +230,22 @@ export const usePromoForm = (id?: string) => {
     } else {
       // Event object call
       if (!e || !e.target) return;
-      const { id, value: targetValue } = e.target;
-      if (!id) return;
-      fieldName = id;
+      const target = e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+      const { id, name, value: targetValue } = target;
+      const dataField = target.dataset?.field;
+      const resolvedFieldName = id || name || dataField;
+
+      if (!resolvedFieldName) {
+        console.warn('usePromoForm: field identifier tidak ditemukan pada elemen input', target);
+        return;
+      }
+
+      fieldName = resolvedFieldName;
       fieldValue = targetValue;
     }
-    
+
     setFormData(prev => ({ ...prev, [fieldName]: fieldValue }));
-    
+
     // Clear errors untuk step saat ini ketika user mengubah input
     setStepErrors(prev => ({ ...prev, [currentStep]: [] }));
     


### PR DESCRIPTION
## Summary
- tambahkan atribut `name` pada input dan textarea form promo agar event membawa identifier field yang konsisten
- perbarui handler `handleInputChange` untuk memakai `id`, `name`, atau `data-field` sehingga perubahan pengguna selalu tersimpan

## Testing
- pnpm lint *(gagal: parse error legacy di src/config/smartLazyLoading.ts)*
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfab14aff4832e96674e5fe306c3f8