### PR TITLE
Limit SPA rewrite to HTML navigation requests

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,6 @@
     { "source": "/assets/(.*)", "destination": "/assets/$1" },
     { "source": "/favicon.ico", "destination": "/favicon.ico" },
     { "source": "/manifest.json", "destination": "/manifest.json" },
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/((?!.*\\.).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- batasi aturan rewrite SPA agar hanya mengenai rute tanpa ekstensi sehingga permintaan aset tetap menuju file aslinya

## Testing
- pnpm lint *(gagal: sudah ada Parsing error di src/config/smartLazyLoading.ts)*
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfadfd0eac832e847155d46bff223c