### PR TITLE
fix: enable add transaction navigation

### DIFF
--- a/src/components/financial/FinancialReportPage.tsx
+++ b/src/components/financial/FinancialReportPage.tsx
@@ -147,6 +147,7 @@ const FinancialReportPage: React.FC = () => {
           dateRange={dateRangeForPicker}
           isLoading={financialCore.isLoading}
           isMobile={isMobile}
+          actionsDisabled={financialCore.isLoading && !financialCore.hasTransactions}
         />
 
         {/* Summary Cards */}

--- a/src/components/financial/components/FinancialHeader.tsx
+++ b/src/components/financial/components/FinancialHeader.tsx
@@ -11,6 +11,7 @@ interface FinancialHeaderProps {
   dateRange: { from: Date; to: Date } | undefined;
   isLoading: boolean;
   isMobile: boolean;
+  actionsDisabled?: boolean;
 }
 
 export const FinancialHeader: React.FC<FinancialHeaderProps> = ({
@@ -19,9 +20,17 @@ export const FinancialHeader: React.FC<FinancialHeaderProps> = ({
   onDateRangeChange,
   dateRange,
   isLoading,
-  isMobile
+  isMobile,
+  actionsDisabled = false
 }) => {
-  console.log('📊 FinancialHeader - isLoading:', isLoading, 'isMobile:', isMobile);
+  console.log(
+    '📊 FinancialHeader - isLoading:',
+    isLoading,
+    'isMobile:',
+    isMobile,
+    'actionsDisabled:',
+    actionsDisabled
+  );
   return (
     <div className="bg-gradient-to-r from-orange-500 to-red-500 rounded-xl p-6 text-white border">
       <div className="flex flex-col md:flex-row md:flex-wrap md:items-center md:justify-between gap-4">
@@ -44,7 +53,7 @@ export const FinancialHeader: React.FC<FinancialHeaderProps> = ({
               console.log('Desktop Tambah Transaksi button clicked');
               onAddTransaction();
             }}
-            disabled={isLoading}
+            disabled={actionsDisabled}
             className="flex items-center gap-2 bg-white bg-opacity-20 text-white border border-white border-opacity-30 hover:bg-white hover:bg-opacity-30 backdrop-blur-sm"
           >
             <Plus className="h-4 w-4" />
@@ -78,7 +87,7 @@ export const FinancialHeader: React.FC<FinancialHeaderProps> = ({
             console.log('Mobile Tambah Transaksi button clicked');
             onAddTransaction();
           }}
-          disabled={isLoading}
+          disabled={actionsDisabled}
           className="w-full flex items-center justify-center gap-2 bg-white bg-opacity-20 text-white border border-white border-opacity-30 hover:bg-white hover:bg-opacity-30 backdrop-blur-sm"
         >
           <Plus className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- add an `actionsDisabled` flag to `FinancialHeader` so the CTA respects a dedicated disable signal instead of the loading prop
- drive the header button state from `FinancialReportPage` using `isLoading && !hasTransactions` so it stays clickable after data loads

## Testing
- `pnpm lint` *(fails: pre-existing parsing error in src/config/smartLazyLoading.ts)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68cfaaf2ea70832e8f9bc7ec643a7cd4