### PR TITLE
fix: prioritize quantity alias in warehouse sync

### DIFF
--- a/src/components/warehouse/services/warehouseSyncService.refactored.ts
+++ b/src/components/warehouse/services/warehouseSyncService.refactored.ts
@@ -19,6 +19,8 @@ export interface PurchaseItem {
   nama?: string;
   kategori?: string;
   quantity?: number;
+  qty?: number;
+  qty_base?: number;
   kuantitas?: number;
   jumlah?: number;
   unitPrice?: number;
@@ -121,7 +123,16 @@ export const extractItemId = (item: PurchaseItem): string | undefined => {
  * @returns Kuantitas atau 0 jika tidak ditemukan
  */
 export const extractQuantity = (item: PurchaseItem): number => {
-  return toNumber(item.kuantitas ?? item.jumlah ?? 0);
+  const rawQuantity =
+    item.quantity ??
+    item.kuantitas ??
+    item.jumlah ??
+    item.qty_base ??
+    item.qty ??
+    0;
+
+  const quantity = toNumber(rawQuantity);
+  return quantity < 0 ? 0 : quantity;
 };
 
 /**


### PR DESCRIPTION
## Summary
- prioritize the `quantity` field when extracting purchase quantities and retain legacy fallbacks
- guard against negative values while still normalizing with `toNumber`
- extend the purchase item typing with additional quantity aliases used during sync flows

## Testing
- pnpm lint
- pnpm build
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68d0dbbe02b0832e8100b9e534c58710