### PR TITLE
fix: handle missing bahan baku gracefully

### DIFF
--- a/src/components/warehouse/services/warehouseSyncService.refactored.ts
+++ b/src/components/warehouse/services/warehouseSyncService.refactored.ts
@@ -188,17 +188,25 @@ export const applyPurchaseToWarehouse = async (purchase: Purchase): Promise<void
     }
 
     try {
-      const { data: existing, error: fetchError } = await supabase
+      const { data: existingData, error: fetchError } = await supabase
         .from('bahan_baku')
         .select('id, stok, harga_rata_rata, harga_satuan')
         .eq('id', itemId)
         .eq('user_id', purchase.userId)
-        .single();
+        .maybeSingle();
+
+      const fetchErrorCode = (fetchError as { code?: string } | null)?.code;
 
       if (fetchError) {
-        logger.error('Error fetching existing item:', fetchError);
-        continue;
+        if (fetchErrorCode === 'PGRST116') {
+          logger.debug('Item not found, will create new entry:', { itemId });
+        } else {
+          logger.error('Error fetching existing item:', fetchError);
+          continue;
+        }
       }
+
+      const existing = fetchErrorCode === 'PGRST116' ? null : existingData;
 
       const oldStock = existing?.stok ?? 0;
       const oldWac = existing?.harga_rata_rata ?? existing?.harga_satuan ?? 0;


### PR DESCRIPTION
## Summary
- gunakan `maybeSingle()` saat mengambil data bahan baku agar respon kosong dianggap normal
- perlakukan error `PGRST116` sebagai kondisi pembuatan item baru dan jaga logging untuk error lain

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0dbbf21c0832e8820e212f0c52387