### PR TITLE
fix: tampilkan nama supplier di halaman purchase

### DIFF
--- a/src/components/purchase/components/OptimizedPurchaseTable.tsx
+++ b/src/components/purchase/components/OptimizedPurchaseTable.tsx
@@ -139,7 +139,9 @@ const createPurchaseColumns = (
     sortable: true,
     render: (purchase: Purchase) => (
       <span className="text-sm text-gray-900">
-        {purchase.supplier || 'Supplier Tidak Diketahui'}
+        {getSupplierName
+          ? getSupplierName(purchase.supplier)
+          : (purchase.supplier || 'Supplier Tidak Diketahui')}
       </span>
     )
   },

--- a/src/components/purchase/components/PurchaseTable.tsx
+++ b/src/components/purchase/components/PurchaseTable.tsx
@@ -470,7 +470,7 @@ const PurchaseTableCore: React.FC<PurchaseTablePropsExtended> = ({
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center justify-between">
                           <h4 className="font-medium text-gray-900 truncate">
-                            {purchase.supplier || 'Supplier Tidak Diketahui'}
+                            {getSupplierNameFromTableContext(purchase.supplier)}
                           </h4>
                           <div className="ml-2">
                             <StatusBadge status={purchase.status} />
@@ -588,6 +588,7 @@ const PurchaseTableCore: React.FC<PurchaseTablePropsExtended> = ({
                       onDelete={openDelete}
                       onStatusChange={(id, newStatus) => Promise.resolve(handleStatusChange(id, newStatus))}
                       onEditStatus={setEditingStatusId}
+                      getSupplierName={getSupplierName}
                     />
                   ))}
                 </TableBody>
@@ -633,6 +634,7 @@ const PurchaseTableCore: React.FC<PurchaseTablePropsExtended> = ({
         isUpdating={false}
         onConfirm={dialogHandlers.confirmStatusChange}
         onCancel={dialogHandlers.cancelStatusChange}
+        getSupplierName={getSupplierName}
       />
 
       <AlertDialog open={dialogState.deleteConfirmation.isOpen} onOpenChange={(open: boolean) => !open && dialogHandlers.cancelDelete()}>

--- a/src/components/purchase/components/StatusChangeConfirmationDialog.tsx
+++ b/src/components/purchase/components/StatusChangeConfirmationDialog.tsx
@@ -29,6 +29,7 @@ interface StatusChangeConfirmationDialogProps {
   isUpdating: boolean;
   onConfirm: () => void;
   onCancel: () => void;
+  getSupplierName?: (supplierId: string) => string;
 }
 
 const StatusChangeConfirmationDialog: React.FC<StatusChangeConfirmationDialogProps> = ({
@@ -38,7 +39,8 @@ const StatusChangeConfirmationDialog: React.FC<StatusChangeConfirmationDialogPro
   validation,
   isUpdating,
   onConfirm,
-  onCancel
+  onCancel,
+  getSupplierName
 }) => {
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
@@ -166,7 +168,10 @@ const StatusChangeConfirmationDialog: React.FC<StatusChangeConfirmationDialogPro
 
             {/* Purchase Details */}
             <div className="text-sm text-gray-600">
-              <p><span className="font-medium">Supplier:</span> {purchase.supplier}</p>
+              <p>
+                <span className="font-medium">Supplier:</span>{' '}
+                {getSupplierName ? getSupplierName(purchase.supplier) : (purchase.supplier || 'Supplier Tidak Diketahui')}
+              </p>
               <p><span className="font-medium">Total Items:</span> {purchase.items.length} item</p>
               <p><span className="font-medium">Total Nilai:</span> Rp {(purchase.totalNilai ?? purchase.total_nilai ?? 0).toLocaleString('id-ID')}</p>
             </div>

--- a/src/components/purchase/components/table/PurchaseTableRow.tsx
+++ b/src/components/purchase/components/table/PurchaseTableRow.tsx
@@ -18,6 +18,7 @@ interface PurchaseTableRowProps {
   onStatusChange: (purchaseId: string, newStatus: string) => Promise<void>;
   onEdit: (purchase: Purchase) => void;
   onDelete: (purchase: Purchase) => void;
+  getSupplierName?: (supplierId: string) => string;
 }
 
 export const PurchaseTableRow: React.FC<PurchaseTableRowProps> = ({
@@ -28,11 +29,19 @@ export const PurchaseTableRow: React.FC<PurchaseTableRowProps> = ({
   onEditStatus,
   onStatusChange,
   onEdit,
-  onDelete
+  onDelete,
+  getSupplierName
 }) => {
+  const resolvedSupplierName = React.useMemo(() => {
+    if (!getSupplierName) {
+      return purchase.supplier || 'Supplier Tidak Diketahui';
+    }
+    return getSupplierName(purchase.supplier) || 'Supplier Tidak Diketahui';
+  }, [getSupplierName, purchase.supplier]);
+
   return (
-    <TableRow 
-      key={purchase.id} 
+    <TableRow
+      key={purchase.id}
       className="hover:bg-gray-50"
     >
       <TableCell>
@@ -61,7 +70,7 @@ export const PurchaseTableRow: React.FC<PurchaseTableRowProps> = ({
       <TableCell>
         <div>
           <div className="font-medium">
-            {purchase.supplier || 'Supplier Tidak Diketahui'}
+            {resolvedSupplierName}
           </div>
         </div>
       </TableCell>


### PR DESCRIPTION
## Ringkasan
- menampilkan nama supplier melalui helper context di tampilan tabel purchase (mobile dan desktop)
- meneruskan utilitas resolusi supplier ke komponen baris dan dialog konfirmasi status
- memastikan tabel purchase teroptimasi juga memakai nama supplier yang sudah terpetakan

## Pengujian
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0e1c1de3c832e826d427645041140