### PR TITLE
fix: scope warehouse cache by user

### DIFF
--- a/src/components/warehouse/context/WarehouseContext.tsx
+++ b/src/components/warehouse/context/WarehouseContext.tsx
@@ -237,12 +237,12 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({
     isRefetching,
     dataUpdatedAt,
   } = useQuery({
-    queryKey: warehouseQueryKeys.list(),
+    queryKey: [...warehouseQueryKeys.list(), user?.id ?? 'anonymous'],
     queryFn: () => {
       if (isDebugMode) logger.debug('🔄 Warehouse queryFn called');
       return fetchWarehouseData(user?.id);
     },
-    enabled: !!user,
+    enabled: !!user?.id,
     staleTime: 2 * 60 * 1000, // 2 minutes cache to improve performance
     // ✅ Improved retry logic: handle transient 5xx (e.g., 503) with backoff
     retry: (failureCount, err: any) => {


### PR DESCRIPTION
## Summary
- include the authenticated user id in the warehouse list query key so React Query caches data per user session
- keep the warehouse fetch disabled until a concrete user id is available to avoid sharing cached supplier inventories between accounts

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0e1feb524832e8d13a25ce8b88e1f