### PR TITLE
Percepat render awal dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,10 +1,9 @@
 // pages/Dashboard.tsx - Updated to use new trends data
 
-import React, { useState, useMemo, Suspense, lazy, useCallback } from 'react';
+import React, { useState, useMemo, Suspense, lazy, useCallback, useEffect } from 'react';
 import { useDashboardData } from '@/hooks/useDashboardData';
 import { useUserSettings } from '@/contexts/UserSettingsContext';
 import ErrorBoundary from '@/components/dashboard/ErrorBoundary';
-import { SafeSuspense } from '@/components/common/UniversalErrorBoundary';
 import DashboardHeader from '@/components/dashboard/DashboardHeader';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { logger } from '@/utils/logger';
@@ -88,11 +87,22 @@ const Dashboard = () => {
     activities: 1,
     worstProducts: 1
   });
+  const [ownerInputValue, setOwnerInputValue] = useState('');
 
   // 👤 Get settings from context
   const { settings, saveSettings, isLoading: settingsLoading } = useUserSettings();
   const { ownerName } = settings;
   const isMobile = useIsMobile();
+  const isSettingsLoading = settingsLoading;
+
+  useEffect(() => {
+    if (isSettingsLoading) {
+      return;
+    }
+
+    const sanitizedName = ownerName && ownerName !== 'Nama Anda' ? ownerName : '';
+    setOwnerInputValue(sanitizedName);
+  }, [ownerName, isSettingsLoading]);
 
   // Debug logging for settings
   React.useEffect(() => {
@@ -115,11 +125,19 @@ const Dashboard = () => {
   } = useDashboardData(dateRange);
 
   // 👋 Greeting message
-  const greeting = useMemo(() => getGreeting(ownerName), [ownerName]);
+  const greeting = useMemo(
+    () => getGreeting(!isSettingsLoading ? ownerName : undefined),
+    [isSettingsLoading, ownerName]
+  );
 
   const handleOwnerNameSave = useCallback(async (rawName?: string) => {
+    if (isSettingsLoading) {
+      logger.debug('Dashboard - Skipping save because settings are still loading');
+      return;
+    }
+
     const name = rawName?.trim();
-    
+
     // Debug logging
     logger.debug('Dashboard - handleOwnerNameSave called:', { 
       rawName, 
@@ -138,13 +156,14 @@ const Dashboard = () => {
 
     logger.info('Dashboard - Saving owner name:', name);
     const saved = await saveSettings({ ownerName: name });
-    
+
     if (saved) {
       logger.success('Dashboard - Owner name saved successfully');
+      setOwnerInputValue(name);
     } else {
       logger.error('Dashboard - Failed to save owner name');
     }
-  }, [ownerName, saveSettings]);
+  }, [isSettingsLoading, ownerName, saveSettings]);
 
   // 🛡️ Safe date range handler - menggunakan unified date utils
   const handleDateRangeChange = (newRange: { from: Date; to: Date }) => {
@@ -188,15 +207,13 @@ const Dashboard = () => {
   }
 
   // 🔄 Loading state - Wait for both dateRange and settings to load
-  if (!dateRange || !dateRange.from || !dateRange.to || settingsLoading) {
+  if (!dateRange || !dateRange.from || !dateRange.to) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center p-4">
         <div className="text-center">
           <div className="w-16 h-16 border-4 border-orange-500 border-t-transparent rounded-full animate-spin mx-auto mb-6"></div>
           <h2 className="text-xl font-semibold text-gray-700 mb-2">Memuat Dashboard</h2>
-          <p className="text-gray-500">
-            {settingsLoading ? 'Memuat pengaturan...' : 'Sedang menyiapkan data untuk Anda...'}
-          </p>
+          <p className="text-gray-500">Sedang menyiapkan data untuk Anda...</p>
         </div>
       </div>
     );
@@ -218,13 +235,17 @@ const Dashboard = () => {
               />
               
               {/* 👤 Owner Name Quick Setting */}
-              <div className="flex items-center space-x-2 bg-amber-50 border border-amber-200 rounded-lg px-4 py-2.5 text-sm">
+              <div
+                className="flex items-center space-x-2 bg-amber-50 border border-amber-200 rounded-lg px-4 py-2.5 text-sm"
+                aria-busy={isSettingsLoading}
+              >
                 <span className="text-amber-700 font-medium">👋</span>
                 <input
                   type="text"
-                  placeholder="Masukkan nama Anda..."
-                  className="bg-transparent border-none outline-none placeholder-amber-500 text-amber-800 font-medium w-36"
-                  defaultValue={ownerName && ownerName !== 'Nama Anda' ? ownerName : ''}
+                  placeholder={isSettingsLoading ? 'Memuat nama...' : 'Masukkan nama Anda...'}
+                  className={`bg-transparent border-none outline-none placeholder-amber-500 text-amber-800 font-medium w-36 transition-opacity ${isSettingsLoading ? 'opacity-60 cursor-not-allowed' : ''}`}
+                  value={ownerInputValue}
+                  onChange={(event) => setOwnerInputValue(event.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {
                       const input = e.target as HTMLInputElement;
@@ -237,7 +258,14 @@ const Dashboard = () => {
                       handleOwnerNameSave(input.value);
                     }
                   }}
+                  disabled={isSettingsLoading}
                 />
+                {isSettingsLoading && (
+                  <div className="flex items-center gap-1 text-amber-600 text-xs">
+                    <span className="w-3 h-3 border-[2px] border-amber-300 border-t-transparent rounded-full animate-spin" />
+                    <span>Memuat pengaturan...</span>
+                  </div>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- menghilangkan spinner global yang menunggu pengaturan pengguna selesai dimuat
- menambahkan state input nama pemilik yang tersinkronisasi agar tetap responsif saat data selesai didapat
- menonaktifkan penyimpanan nama ketika pengaturan masih loading dan menampilkan indikator lokal di input

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0eea13a04832e87e7c088ec523d18