### PR TITLE
Perbaiki pengiriman items order sebagai array jsonb

### DIFF
--- a/src/components/orders/services/orderService.ts
+++ b/src/components/orders/services/orderService.ts
@@ -183,7 +183,7 @@ export async function addOrder(userId: string, order: NewOrder): Promise<Order> 
         telepon_pelanggan: order.teleponPelanggan || '',
         email_pelanggan: order.emailPelanggan || '',
         alamat_pengiriman: order.alamatPengiriman || '',
-        items: JSON.stringify(Array.isArray(order.items) ? order.items : []), // ✅ FIXED: Stringify items for JSON
+        items: Array.isArray(order.items) ? order.items : [],
         total_pesanan: Number(order.totalPesanan) || 0,
         catatan: order.catatan || '',
         subtotal: Number(order.subtotal) || 0,
@@ -248,7 +248,7 @@ export async function addOrder(userId: string, order: NewOrder): Promise<Order> 
     status: validateStatus(order.status),
     tanggal: toSafeISOString(order.tanggal || new Date()),
     total_pesanan: Number(order.totalPesanan) || 0,
-    items: JSON.stringify(Array.isArray(order.items) ? order.items : []),
+    items: Array.isArray(order.items) ? order.items : [],
     subtotal: Number(order.subtotal) || 0,
     pajak: Number(order.pajak) || 0,
     catatan: order.catatan || '',

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -918,7 +918,7 @@ export type Database = {
       }
       create_new_order: {
         Args: { order_data: Json }
-        Returns: string
+        Returns: Json
       }
       get_order_statistics: {
         Args: { p_user_id: string }

--- a/supabase/sql/convert_orders_items_to_jsonb.sql
+++ b/supabase/sql/convert_orders_items_to_jsonb.sql
@@ -1,0 +1,4 @@
+-- Konversi kolom orders.items yang masih berupa string menjadi array jsonb
+UPDATE public.orders
+SET items = COALESCE(items::text::jsonb, '[]'::jsonb)
+WHERE jsonb_typeof(items) = 'string';


### PR DESCRIPTION
## Ringkasan
- mengirim field `items` ke RPC `create_new_order` dan fallback insert sebagai array jsonb tanpa stringify
- memperbarui tipe Supabase agar `create_new_order` mengembalikan objek JSON
- menambahkan skrip SQL untuk mengonversi nilai `orders.items` bertipe string menjadi array `jsonb`

## Pengujian
- `pnpm lint`
- `pnpm build`
- `node test-order-completion.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68d12b426148832ebdf47fb0ca68e83a