### PR TITLE
fix: guard expiry date parsing in warehouse forms

### DIFF
--- a/src/components/warehouse/dialogs/AddEditDialog.tsx
+++ b/src/components/warehouse/dialogs/AddEditDialog.tsx
@@ -223,7 +223,7 @@ const AddEditDialog: React.FC<AddEditDialogProps> = ({
         minimum: toNumber(item.minimum),
         satuan: item.satuan || '',
         harga: toNumber(item.harga),
-        expiry: item.expiry ? item.expiry.split('T')[0] : '',
+        expiry: warehouseUtils.formatDateForInput(item.expiry),
       });
     } else {
       setFormData(initialFormData);

--- a/src/components/warehouse/pages/EditBahanBaku.tsx
+++ b/src/components/warehouse/pages/EditBahanBaku.tsx
@@ -20,6 +20,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { warehouseApi } from '../services/warehouseApi';
 import { FNB_COGS_CATEGORIES } from '@/components/profitAnalysis/constants/profitConstants';
 import { toNumber } from '../utils/typeUtils';
+import { warehouseUtils } from '../services/warehouseUtils';
 
 interface FormData {
   nama: string;
@@ -89,7 +90,7 @@ export const EditBahanBaku: React.FC = () => {
         minimum: toNumber(existingItem.minimum),
         satuan: existingItem.satuan || '',
         harga: toNumber(existingItem.harga),
-        expiry: existingItem.expiry ? existingItem.expiry.split('T')[0] : '',
+        expiry: warehouseUtils.formatDateForInput(existingItem.expiry),
         keterangan: existingItem.keterangan || ''
       });
     }

--- a/src/components/warehouse/services/warehouseUtils.ts
+++ b/src/components/warehouse/services/warehouseUtils.ts
@@ -73,6 +73,17 @@ const formatDate = (date: string | Date) =>
   new Intl.DateTimeFormat('id-ID', { year: 'numeric', month: 'short', day: 'numeric' })
     .format(typeof date === 'string' ? new Date(date) : date);
 
+const formatDateForInput = (value?: string | Date | null): string => {
+  if (!value) return '';
+
+  const parsedDate = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return '';
+  }
+
+  return parsedDate.toISOString().split('T')[0];
+};
+
 // ✅ UPDATED: Use new critical stock logic with 20% buffer
 const getLowStockItems = (items: BahanBakuFrontend[]) => {
   return items.filter(item => {
@@ -172,6 +183,7 @@ export const warehouseUtils = {
 
   formatCurrency,
   formatDate,
+  formatDateForInput,
 
   formatStockLevel: (current: number, minimum: number) => {
     if (current === 0) return { level: 'out' as const, percentage: 0, color: 'red' };


### PR DESCRIPTION
## Summary
- tambahkan helper `formatDateForInput` di util gudang untuk memformat tanggal secara aman
- gunakan helper baru saat mengisi form edit bahan baku halaman penuh dan dialog agar tidak melempar kesalahan

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d136c32d4c832eb87cee2a0e700187