### PR TITLE
fix: Add missing imports for AutoLinkingPopup and related utilities

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,5 +1,5 @@
 {
-  "commitHash": "59026d539c8fc310438e3004c4fa4ffe8be81f71",
-  "buildTimestamp": "2025-09-22T15:23:35.295Z",
-  "buildId": "5d7c8df750b51d09"
+  "commitHash": "840fd37ae2c84f490ec622c5e2664b57fd712317",
+  "buildTimestamp": "2025-09-22T15:27:22.281Z",
+  "buildId": "241010e326c0f48a"
 }

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -7,6 +7,10 @@ import { usePaymentContext } from "@/contexts/PaymentContext";
 import { useAppLayout } from "@/hooks/useAppLayout";
 import { MobileLayout } from "./MobileLayout";
 import { DesktopLayout } from "./DesktopLayout";
+import { AutoLinkingPopup } from "@/components/popups";
+import { logger } from "@/utils/logger";
+import { supabase } from '@/integrations/supabase/client';
+import { safeStorageGet, safeStorageRemove } from '@/utils/auth/safeStorage';
 
 export const AppLayout = () => {
   const isMobile = useIsMobile();


### PR DESCRIPTION
- Add AutoLinkingPopup import to AppLayout.tsx
- Add logger import for version checking and error logging
- Add supabase client import for AutoLinkingPopup functionality
- Add safeStorage imports for update flag management
- Fix 'AutoLinkingPopup is not defined' runtime error
- Ensure all required dependencies are properly imported

This resolves the runtime error where AutoLinkingPopup component was used but not imported, causing the app to crash on load.