### PR TITLE
fix: normalize recipe ingredient pricing data

### DIFF
--- a/src/components/recipe/components/RecipeForm/index.tsx
+++ b/src/components/recipe/components/RecipeForm/index.tsx
@@ -28,7 +28,7 @@ const CostCalculationStep = React.lazy(() =>
     })
 );
 // Utils and types
-import { validateRecipeData, calculateHPP } from '../../services/recipeUtils';
+import { validateRecipeData, calculateHPP, normalizeBahanResep } from '../../services/recipeUtils';
 import { recipeApi } from '../../services/recipeApi';
 import { safeDom } from '@/utils/browserApiSafeWrappers';
 import {
@@ -187,11 +187,13 @@ const RecipeForm: React.FC<RecipeFormProps> = ({
           kategoriResep: r.kategoriResep ?? r.kategori_resep ?? '',
           deskripsi: r.deskripsi ?? '',
           fotoUrl: r.fotoUrl ?? r.foto_url ?? '',
-          bahanResep: Array.isArray(r.bahanResep)
-            ? [...r.bahanResep]
+        bahanResep: normalizeBahanResep(
+          Array.isArray(r.bahanResep)
+            ? r.bahanResep
             : Array.isArray(r.bahan_resep)
-              ? [...r.bahan_resep]
-              : [],
+              ? r.bahan_resep
+              : []
+        ),
           biayaTenagaKerja: r.biayaTenagaKerja ?? r.biaya_tenaga_kerja ?? 0,
           biayaOverhead: r.biayaOverhead ?? r.biaya_overhead ?? 0,
           marginKeuntunganPersen: r.marginKeuntunganPersen ?? r.margin_keuntungan_persen ?? 0,

--- a/src/components/recipe/components/RecipeFormPage.tsx
+++ b/src/components/recipe/components/RecipeFormPage.tsx
@@ -32,7 +32,7 @@ const CostCalculationStep = React.lazy(() =>
 );
 
 // Utils and types
-import { validateRecipeData, calculateHPP } from '@/components/recipe/services/recipeUtils';
+import { validateRecipeData, calculateHPP, normalizeBahanResep } from '@/components/recipe/services/recipeUtils';
 import { recipeApi } from '@/components/recipe/services/recipeApi';
 import {
   type Recipe,
@@ -198,11 +198,13 @@ const RecipeFormPage: React.FC<RecipeFormPageProps> = React.memo(({
         kategoriResep: r.kategoriResep ?? r.kategori_resep ?? '',
         deskripsi: r.deskripsi ?? '',
         fotoUrl: r.fotoUrl ?? r.foto_url ?? '',
-        bahanResep: Array.isArray(r.bahanResep)
-          ? [...r.bahanResep]
-          : Array.isArray(r.bahan_resep)
-            ? [...r.bahan_resep]
-            : [],
+        bahanResep: normalizeBahanResep(
+          Array.isArray(r.bahanResep)
+            ? r.bahanResep
+            : Array.isArray(r.bahan_resep)
+              ? r.bahan_resep
+              : []
+        ),
         biayaTenagaKerja: r.biayaTenagaKerja ?? r.biaya_tenaga_kerja ?? 0,
         biayaOverhead: r.biayaOverhead ?? r.biaya_overhead ?? 0,
         marginKeuntunganPersen: r.marginKeuntunganPersen ?? r.margin_keuntungan_persen ?? 0,

--- a/src/components/recipe/services/recipeApi.ts
+++ b/src/components/recipe/services/recipeApi.ts
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/utils/logger';
 import { getCurrentUserId as getAuthUserId } from '@/utils/authHelpers';
 import { Recipe, RecipeDB, NewRecipe } from '../types';
+import { normalizeBahanResep } from './recipeUtils';
 import { OptimizedQueryBuilder, OPTIMIZED_SELECTS, PaginationOptimizer } from '@/utils/egressOptimization';
 
 // import transformers from './recipeTransformers';
@@ -30,31 +31,33 @@ class RecipeApiService {
   }
   // Transform database format to frontend format
   private transformFromDB(dbItem: RecipeDB): Recipe {
+    const normalizedIngredients = normalizeBahanResep(dbItem.bahan_resep);
+
     return {
-    id: dbItem.id,
-    user_id: dbItem.user_id,
-    created_at: new Date(dbItem.created_at),
-    updated_at: new Date(dbItem.updated_at),
-    nama_resep: dbItem.nama_resep,
-    jumlah_porsi: Number(dbItem.jumlah_porsi),
-    kategori_resep: dbItem.kategori_resep,
-    deskripsi: dbItem.deskripsi,
-    foto_url: dbItem.foto_url,
-    foto_base64: dbItem.foto_base64,
-    bahan_resep: dbItem.bahan_resep || [],
-    biaya_tenaga_kerja: Number(dbItem.biaya_tenaga_kerja) || 0,
-    biaya_overhead: Number(dbItem.biaya_overhead) || 0,
-    margin_keuntungan_persen: Number(dbItem.margin_keuntungan_persen) || 0,
-    total_hpp: Number(dbItem.total_hpp) || 0,
-    hpp_per_porsi: Number(dbItem.hpp_per_porsi) || 0,
-    harga_jual_porsi: Number(dbItem.harga_jual_porsi) || 0,
-    jumlah_pcs_per_porsi: Number(dbItem.jumlah_pcs_per_porsi) || 1,
-    hpp_per_pcs: Number(dbItem.hpp_per_pcs) || 0,
-    harga_jual_per_pcs: Number(dbItem.harga_jual_per_pcs) || 0,
-    // Manual pricing fields
-    is_manual_pricing_enabled: Boolean(dbItem.is_manual_pricing_enabled),
-    manual_selling_price_per_portion: dbItem.manual_selling_price_per_portion ? Number(dbItem.manual_selling_price_per_portion) : null,
-    manual_selling_price_per_piece: dbItem.manual_selling_price_per_piece ? Number(dbItem.manual_selling_price_per_piece) : null,
+      id: dbItem.id,
+      user_id: dbItem.user_id,
+      created_at: new Date(dbItem.created_at),
+      updated_at: new Date(dbItem.updated_at),
+      nama_resep: dbItem.nama_resep,
+      jumlah_porsi: Number(dbItem.jumlah_porsi),
+      kategori_resep: dbItem.kategori_resep,
+      deskripsi: dbItem.deskripsi,
+      foto_url: dbItem.foto_url,
+      foto_base64: dbItem.foto_base64,
+      bahan_resep: normalizedIngredients,
+      biaya_tenaga_kerja: Number(dbItem.biaya_tenaga_kerja) || 0,
+      biaya_overhead: Number(dbItem.biaya_overhead) || 0,
+      margin_keuntungan_persen: Number(dbItem.margin_keuntungan_persen) || 0,
+      total_hpp: Number(dbItem.total_hpp) || 0,
+      hpp_per_porsi: Number(dbItem.hpp_per_porsi) || 0,
+      harga_jual_porsi: Number(dbItem.harga_jual_porsi) || 0,
+      jumlah_pcs_per_porsi: Number(dbItem.jumlah_pcs_per_porsi) || 1,
+      hpp_per_pcs: Number(dbItem.hpp_per_pcs) || 0,
+      harga_jual_per_pcs: Number(dbItem.harga_jual_per_pcs) || 0,
+      // Manual pricing fields
+      is_manual_pricing_enabled: Boolean(dbItem.is_manual_pricing_enabled),
+      manual_selling_price_per_portion: dbItem.manual_selling_price_per_portion ? Number(dbItem.manual_selling_price_per_portion) : null,
+      manual_selling_price_per_piece: dbItem.manual_selling_price_per_piece ? Number(dbItem.manual_selling_price_per_piece) : null,
     };
   }
 
@@ -67,7 +70,9 @@ class RecipeApiService {
     const deskripsi = recipe.deskripsi;
     const foto_url = recipe.foto_url ?? recipe.fotoUrl;
     const foto_base64 = recipe.foto_base64 ?? recipe.fotoBase64;
-    const bahan_resep = recipe.bahan_resep ?? recipe.bahanResep;
+    const bahan_resep = normalizeBahanResep(
+      recipe.bahan_resep ?? recipe.bahanResep
+    );
     const biaya_tenaga_kerja = recipe.biaya_tenaga_kerja ?? recipe.biayaTenagaKerja ?? 0;
     const biaya_overhead = recipe.biaya_overhead ?? recipe.biayaOverhead ?? 0;
     const margin_keuntungan_persen = recipe.margin_keuntungan_persen ?? recipe.marginKeuntunganPersen ?? 0;


### PR DESCRIPTION
## Summary
- normalize daftar bahan resep untuk menyamakan penamaan field lama dan memastikan nilai jumlah, harga satuan, serta total harga selalu numerik
- gunakan data bahan yang sudah dinormalisasi pada lapisan API Supabase agar penyimpanan dan pembacaan resep konsisten
- terapkan normalisasi yang sama saat mengisi ulang formulir resep sehingga bahan lama menampilkan harga satuan dan total dengan benar

## Testing
- pnpm lint *(gagal: check-warehouse.js Parsing error: Unexpected token as – isu bawaan yang belum diperbaiki)*
- pnpm build


------
https://chatgpt.com/codex/tasks/task_e_68d39a32bbd0832ea8b8a3af77323c7e